### PR TITLE
make required attributes work the front end (solved issue #690)

### DIFF
--- a/src/frontend/components/property-type/default-type/edit.tsx
+++ b/src/frontend/components/property-type/default-type/edit.tsx
@@ -37,6 +37,7 @@ const SelectEdit: FC<CombinedProps> = (props) => {
       isClearable
       styles={styles}
       value={selected}
+      required={property.isRequired}
       options={property.availableValues}
       onChange={s => onChange(property.path, s?.value ?? '')}
       isDisabled={property.isDisabled}
@@ -60,6 +61,7 @@ const TextEdit: FC<CombinedProps> = (props) => {
     <Input
       id={property.path}
       name={property.path}
+      required={property.isRequired}
       onChange={e => setValue(e.target.value)}
       onBlur={() => onChange(property.path, value)}
       // handle clicking ENTER


### PR DESCRIPTION
add required attribute to the input and not only to the label ...

This will fix the bug where `isRequired` property will block (html5) form submit for required fields

see issue #690
