### PR TITLE
feat: add description field

### DIFF
--- a/src/backend/decorators/property/property-decorator.ts
+++ b/src/backend/decorators/property/property-decorator.ts
@@ -278,6 +278,7 @@ class PropertyDecorator {
       resourceId: this._resource.id(),
       isVirtual: this.isVirtual,
       props: this.options.props || {},
+      description: this.options.description,
     }
   }
 

--- a/src/backend/decorators/property/property-options.interface.ts
+++ b/src/backend/decorators/property/property-options.interface.ts
@@ -110,4 +110,6 @@ export default interface PropertyOptions {
    * @new In version 3.3
    */
   reference?: string;
+
+  description?: string;
 }

--- a/src/frontend/components/property-type/boolean/edit.tsx
+++ b/src/frontend/components/property-type/boolean/edit.tsx
@@ -29,6 +29,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
         {...property.props}
       />
       <PropertyLabel property={property} props={{ inline: true }} />
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/components/property-type/datetime/edit.tsx
+++ b/src/frontend/components/property-type/datetime/edit.tsx
@@ -20,6 +20,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
         propertyType={property.type}
         {...property.props}
       />
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/components/property-type/default-type/edit.tsx
+++ b/src/frontend/components/property-type/default-type/edit.tsx
@@ -18,6 +18,7 @@ const Edit: FC<CombinedProps> = (props) => {
     <FormGroup error={Boolean(error)}>
       <PropertyLabel property={property} />
       {property.availableValues ? <SelectEdit {...props} /> : <TextEdit {...props} />}
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/components/property-type/password/edit.tsx
+++ b/src/frontend/components/property-type/password/edit.tsx
@@ -44,6 +44,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
           <Icon icon="View" />
         </Button>
       </InputGroup>
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/components/property-type/reference/edit.tsx
+++ b/src/frontend/components/property-type/reference/edit.tsx
@@ -88,6 +88,7 @@ const Edit: FC<CombinedProps> = (props) => {
         isLoading={loadingRecord}
         {...property.props}
       />
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error?.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/components/property-type/richtext/edit.tsx
+++ b/src/frontend/components/property-type/richtext/edit.tsx
@@ -42,6 +42,7 @@ const Edit: FC<EditPropertyProps> = (props) => {
         onChange={content => onChange(property.path, content)}
         quill={quill}
       />
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error?.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/components/property-type/textarea/edit.tsx
+++ b/src/frontend/components/property-type/textarea/edit.tsx
@@ -32,6 +32,7 @@ const Edit: FC<EditPropertyProps> = (props) => {
         disabled={property.isDisabled}
         {...property.props}
       />
+      {property.description && <FormMessage>{property.description}</FormMessage>}
       <FormMessage>{error && error.message}</FormMessage>
     </FormGroup>
   )

--- a/src/frontend/interfaces/property-json/property-json.interface.ts
+++ b/src/frontend/interfaces/property-json/property-json.interface.ts
@@ -47,6 +47,8 @@ export interface PropertyJSON {
    * Property label
    */
   label: string;
+
+  description?: string;
   /**
    * One of {@link PropertyType}s
    */


### PR DESCRIPTION
This commit adds the ability to specify a description on the `PropertyOptions` that will be displayed as another `<FormMessage>` below the standard inputs if defined. This makes it easier to provide some more context on fields when the objects become large and nested.

This issue describes more or less the same issue: https://github.com/SoftwareBrothers/adminjs/issues/909