### PR TITLE
Fix AdminJS.bundle on windows

### DIFF
--- a/src/adminjs.ts
+++ b/src/adminjs.ts
@@ -303,7 +303,7 @@ class AdminJS {
     const extensions = ['.jsx', '.js', '.ts', '.tsx']
     let filePath = ''
     const componentId = componentName || `Component${nextId}`
-    if (src[0] === '/') {
+    if (path.isAbsolute(src)) {
       filePath = src
     } else {
       filePath = relativeFilePathResolver(src, /.*\.{1}bundle/)


### PR DESCRIPTION
Calling `AdminJS.bundle` with an absolute path fails on windows, because the code that checks if the path is absolute doesn't work with windows paths, which start with drive letters.

Using `path.isAbsolute` from nodeJS fixes this.

The error my colleague was getting:
![image](https://user-images.githubusercontent.com/1611595/153622379-30880567-8063-43ae-a660-14a4e979beb1.png)

We tried this fix locally with [patch-package](https://www.npmjs.com/package/patch-package), and it fixed the crash.