### PR TITLE
fix: add 'showResourceActions' to action config

### DIFF
--- a/src/backend/actions/action.interface.ts
+++ b/src/backend/actions/action.interface.ts
@@ -381,7 +381,7 @@ export interface Action <T extends ActionResponse> {
    */
   isAccessible?: boolean | IsFunction;
   /**
-   * if filter should be visible on the sidebar. Only for _resource_ actions
+   * If filter should be visible on the sidebar. Only for _resource_ actions
    *
    * Example of creating new resource action with filter
    *
@@ -398,6 +398,14 @@ export interface Action <T extends ActionResponse> {
    * ```
    */
   showFilter?: boolean;
+  /**
+   * If action should have resource actions buttons displayed above action header.
+   *
+   * Defaults to `true`
+   *
+   * @new in version v5.8.1
+   */
+  showResourceActions?: boolean;
   /**
    * Type of an action - could be either _resource_, _record_ or _bulk_.
    *

--- a/src/backend/decorators/action/action-decorator.ts
+++ b/src/backend/decorators/action/action-decorator.ts
@@ -326,6 +326,12 @@ class ActionDecorator {
     return !!this.action.handler
   }
 
+  showResourceActions(): boolean {
+    if (this.action.showResourceActions === undefined) return true
+
+    return !!this.action.showResourceActions
+  }
+
   /**
    * Serializes action to JSON format
    *
@@ -343,6 +349,7 @@ class ActionDecorator {
       resourceId,
       guard: this.action.guard ? this._admin.translateMessage(this.action.guard, resourceId) : '',
       showFilter: !!this.action.showFilter,
+      showResourceActions: this.showResourceActions(),
       component: this.action.component,
       showInDrawer: !!this.action.showInDrawer,
       hideActionHeader: !!this.action.hideActionHeader,

--- a/src/frontend/components/app/action-header/action-header.tsx
+++ b/src/frontend/components/app/action-header/action-header.tsx
@@ -67,7 +67,9 @@ export const ActionHeader: React.FC<ActionHeaderProps> = (props) => {
 
   // list and new actions are special and are are always
   const customResourceButtons = actionsToButtonGroup({
-    actions: resource.resourceActions.filter(ra => !['list', 'new'].includes(ra.name)),
+    actions: action.showResourceActions
+      ? resource.resourceActions.filter(ra => !['list', 'new'].includes(ra.name))
+      : [],
     params: { resourceId },
     handleClick: handleActionClick,
   })

--- a/src/frontend/components/spec/action-json.factory.ts
+++ b/src/frontend/components/spec/action-json.factory.ts
@@ -7,6 +7,7 @@ factory.define<ActionJSON>('ActionJSON', Object, {
   name: factory.sequence('ActionJSON.name', n => `action${n}`),
   label: factory.sequence('ActionJSON.label', n => `action ${n}`),
   showFilter: false,
+  showResourceActions: true,
   resourceId: 'resource',
   hideActionHeader: false,
   containerWidth: 1,

--- a/src/frontend/interfaces/action/action-json.interface.ts
+++ b/src/frontend/interfaces/action/action-json.interface.ts
@@ -32,6 +32,14 @@ export interface ActionJSON {
    */
   showFilter: boolean;
   /**
+   * If action should have resource actions buttons displayed above action header.
+   *
+   * Defaults to `true`
+   *
+   * @new in version 5.8.1
+   */
+  showResourceActions: boolean;
+  /**
    * Action component. When set to false action will be invoked immediately after clicking it,
    * to put in another words: there wont be an action view
    */


### PR DESCRIPTION
The purpose is to introduce a configurable option to hide resource actions button at the top of the action's UI (top-right corner). An example is that you e. g. have an action called `Export CSV` which is a `resource` action. It is misleading to display it in `show` or `edit` UI because it exports all/filtered records and not a specific record.