### PR TITLE
Improved ValidationError and ForbiddenError handling in backend

### DIFF
--- a/src/backend/actions/delete/delete-action.spec.ts
+++ b/src/backend/actions/delete/delete-action.spec.ts
@@ -1,0 +1,111 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import sinon from 'sinon'
+
+import DeleteAction from './delete-action'
+import { ActionContext, ActionRequest, ActionHandler, RecordActionResponse } from '../action.interface'
+import BaseRecord from '../../adapters/record/base-record'
+import AdminJS from '../../../adminjs'
+import ViewHelpers from '../../utils/view-helpers/view-helpers'
+import BaseResource from '../../adapters/resource/base-resource'
+import ActionDecorator from '../../decorators/action/action-decorator'
+import NotFoundError from '../../utils/errors/not-found-error'
+import { ValidationError } from '../../utils/errors/validation-error'
+import { RecordJSON } from '../../../frontend/interfaces'
+import { CurrentAdmin } from '../../../current-admin.interface'
+
+
+chai.use(chaiAsPromised)
+
+describe('DeleteAction', function () {
+  let data: ActionContext
+  const request = {
+    params: {},
+    method: 'post',
+  } as ActionRequest
+  let response: any
+
+  describe('.handler', function () {
+    afterEach(function () {
+      sinon.restore()
+    })
+
+    beforeEach(async function () {
+      data = {
+        _admin: sinon.createStubInstance(AdminJS),
+        translateMessage: sinon.stub<any, string>().returns('translatedMessage'),
+        h: sinon.createStubInstance(ViewHelpers),
+        resource: sinon.createStubInstance(BaseResource),
+        action: sinon.createStubInstance(ActionDecorator) as unknown as ActionDecorator,
+      } as unknown as ActionContext
+    })
+
+    it('throws error when no records are given', async function () {
+      await expect(
+        (DeleteAction.handler as ActionHandler<RecordActionResponse>)(request, response, data),
+      ).to.rejectedWith(NotFoundError)
+    })
+
+    context('A record has been selected', function () {
+      let record: BaseRecord
+      let recordJSON: RecordJSON
+
+      beforeEach(function () {
+        recordJSON = { id: 'someId' } as RecordJSON
+        record = sinon.createStubInstance(BaseRecord, {
+          toJSON: sinon.stub<[(CurrentAdmin)?]>().returns(recordJSON),
+        }) as unknown as BaseRecord
+
+        request.params.recordId = recordJSON.id
+        data.record = record
+      })
+
+      it('returns deleted record, notice and redirectUrl', async function () {
+        const actionResponse = await (
+          DeleteAction.handler as ActionHandler<RecordActionResponse>
+        )(request, response, data)
+
+        expect(actionResponse).to.have.property('notice')
+        expect(actionResponse).to.have.property('redirectUrl')
+        expect(actionResponse).to.have.property('record')
+      })
+
+      context('ValidationError is thrown by Resource.delete', function () {
+        it('returns error notice', async function () {
+          const errorMessage = 'test validation error'
+          data.resource = sinon.createStubInstance(BaseResource, {
+            delete: sinon.stub().rejects(new ValidationError({}, { message: errorMessage })) as any,
+          })
+
+          const actionResponse = await (
+            DeleteAction.handler as ActionHandler<RecordActionResponse>
+          )(request, response, data)
+
+          expect(actionResponse).to.have.property('notice')
+          expect(actionResponse.notice).to.deep.equal({
+            message: errorMessage,
+            type: 'error',
+          })
+          expect(actionResponse).to.have.property('record')
+        })
+
+        it('returns error notice with default message when ValidationError has no baseError', async function () {
+          data.resource = sinon.createStubInstance(BaseResource, {
+            delete: sinon.stub().rejects(new ValidationError({})) as any,
+          })
+
+          const actionResponse = await (
+            DeleteAction.handler as ActionHandler<RecordActionResponse>
+          )(request, response, data)
+
+          expect(actionResponse).to.have.property('notice')
+          expect(actionResponse.notice).to.deep.equal({
+            message: 'translatedMessage',
+            type: 'error',
+          })
+          expect(actionResponse).to.have.property('record')
+        })
+      })
+    })
+  })
+})

--- a/src/backend/actions/delete/delete-action.ts
+++ b/src/backend/actions/delete/delete-action.ts
@@ -38,11 +38,13 @@ export const DeleteAction: Action<RecordActionResponse> = {
     try {
       await resource.delete(request.params.recordId)
     } catch (error) {
-      if (error instanceof ValidationError && error.baseError) {
+      if (error instanceof ValidationError) {
+        const baseMessage = error.baseError?.message
+          || translateMessage('thereWereValidationErrors', resource.id())
         return {
           record: record.toJSON(currentAdmin),
           notice: {
-            message: error.baseError.message,
+            message: baseMessage,
             type: 'error',
           },
         }

--- a/src/backend/actions/edit/edit-action.ts
+++ b/src/backend/actions/edit/edit-action.ts
@@ -57,10 +57,12 @@ export const EditAction: Action<RecordActionResponse> = {
         record: populatedRecord.toJSON(currentAdmin),
       }
     }
+    const baseMessage = populatedRecord.baseError?.message
+      || translateMessage('thereWereValidationErrors', resource.id())
     return {
       record: populatedRecord.toJSON(currentAdmin),
       notice: {
-        message: translateMessage('thereWereValidationErrors'),
+        message: baseMessage,
         type: 'error',
       },
     }

--- a/src/backend/actions/new/new-action.ts
+++ b/src/backend/actions/new/new-action.ts
@@ -51,10 +51,12 @@ export const NewAction: Action<RecordActionResponse> = {
           record: record.toJSON(currentAdmin),
         }
       }
+      const baseMessage = populatedRecord.baseError?.message
+        || translateMessage('thereWereValidationErrors', resource.id())
       return {
         record: record.toJSON(currentAdmin),
         notice: {
-          message: translateMessage('thereWereValidationErrors', resource.id()),
+          message: baseMessage,
           type: 'error',
         },
       }

--- a/src/backend/adapters/record/base-record.spec.ts
+++ b/src/backend/adapters/record/base-record.spec.ts
@@ -8,7 +8,7 @@ import { ParamsType } from './params.type'
 import BaseRecord from './base-record'
 import BaseResource from '../resource/base-resource'
 import BaseProperty from '../property/base-property'
-import ValidationError, { PropertyErrors } from '../../utils/errors/validation-error'
+import ValidationError, { PropertyErrors, RecordError } from '../../utils/errors/validation-error'
 import { ActionDecorator, ResourceDecorator } from '../../decorators'
 
 chai.use(chaiAsPromised)
@@ -99,6 +99,25 @@ describe('Record', function () {
     })
 
     it('stores validation error when they happen', async function () {
+      const baseError: RecordError = {
+        message: 'test base error',
+      }
+      const propertyErrors: PropertyErrors = {
+        param2: {
+          type: 'required',
+          message: 'Field is required',
+        },
+      }
+      resource.create = sinon.stub().rejects(new ValidationError(propertyErrors, baseError))
+      record = new BaseRecord(newParams, resource)
+
+      await record.save()
+
+      expect(record.error('param2')).to.deep.equal(propertyErrors.param2)
+      expect(record.baseError).to.deep.equal(baseError)
+    })
+
+    it('stores validation error when they happen (even when there is no baseError specified)', async function () {
       const propertyErrors: PropertyErrors = {
         param2: {
           type: 'required',
@@ -111,6 +130,7 @@ describe('Record', function () {
       await record.save()
 
       expect(record.error('param2')).to.deep.equal(propertyErrors.param2)
+      expect(record.baseError).to.be.null
     })
   })
 
@@ -137,7 +157,11 @@ describe('Record', function () {
         expect(record.get('param2')).to.equal(newParams.param2)
       })
 
-      it('resets the errors when there are no', function () {
+      it('resets the baseError when there is none', function () {
+        expect((record as any).baseError).to.deep.equal(null)
+      })
+
+      it('resets the errors when there are none', function () {
         expect((record as any).errors).to.deep.equal({})
       })
 
@@ -147,6 +171,9 @@ describe('Record', function () {
     })
 
     context('resource throws validation error', function () {
+      const baseError: RecordError = {
+        message: 'test base error',
+      }
       const propertyErrors: PropertyErrors = {
         param2: {
           type: 'required',
@@ -158,12 +185,16 @@ describe('Record', function () {
         resource = sinon.createStubInstance(BaseResource, {
           properties: sinon.stub<[], BaseProperty[]>().returns(properties),
           update: sinon.stub<[string, Record<string, any>], Promise<ParamsType>>()
-            .rejects(new ValidationError(propertyErrors)),
+            .rejects(new ValidationError(propertyErrors, baseError)),
         })
 
         record = new BaseRecord(params, resource)
 
         this.returnedValue = await record.update(newParams)
+      })
+
+      it('stores validation baseError', function () {
+        expect(record.baseError).to.deep.equal(baseError)
       })
 
       it('stores validation errors', function () {

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -23,7 +23,13 @@ class BaseRecord {
   public params: ParamsType
 
   /**
-   * Object containing all validation errors: this.errors[path] = 'errorMessage'
+   * Object containing any base/overall validation error messages:
+   * this.baseError = { message: 'errorMessage' }
+   */
+  public baseError: RecordError | null
+
+  /**
+   * Object containing all validation errors: this.errors[path] = { message: 'errorMessage' }
    */
   public errors: PropertyErrors
 
@@ -39,6 +45,7 @@ class BaseRecord {
   constructor(params: ParamsType, resource: BaseResource) {
     this.resource = resource
     this.params = params ? flat.flatten(params) : {}
+    this.baseError = null
     this.errors = {}
     this.populated = {}
   }
@@ -132,11 +139,13 @@ class BaseRecord {
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {
+        this.baseError = e.baseError
         this.errors = e.propertyErrors
         return this
       }
       throw e
     }
+    this.baseError = null
     this.errors = {}
     return this
   }
@@ -163,11 +172,13 @@ class BaseRecord {
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {
+        this.baseError = e.baseError
         this.errors = e.propertyErrors
         return this
       }
       throw e
     }
+    this.baseError = null
     this.errors = {}
     return this
   }
@@ -188,11 +199,13 @@ class BaseRecord {
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {
+        this.baseError = e.baseError
         this.errors = e.propertyErrors
         return this
       }
       throw e
     }
+    this.baseError = null
     this.errors = {}
     return this
   }
@@ -276,6 +289,7 @@ class BaseRecord {
     return {
       params: this.params,
       populated,
+      baseError: this.baseError,
       errors: this.errors,
       id: this.id(),
       title: this.resource.decorate().titleOf(this),

--- a/src/backend/decorators/action/action-decorator.spec.ts
+++ b/src/backend/decorators/action/action-decorator.spec.ts
@@ -13,12 +13,14 @@ describe('ActionDecorator', function () {
   let admin: AdminJS
   let resource: BaseResource
   let context: ActionContext
+  let action: ActionDecorator
   let handler: sinon.SinonStub<any, Promise<ActionResponse>>
 
   beforeEach(function () {
     admin = sinon.createStubInstance(AdminJS)
     resource = sinon.createStubInstance(BaseResource)
-    context = { resource, _admin: admin } as ActionContext
+    action = { name: 'myAction' } as ActionDecorator
+    context = { resource, _admin: admin, action } as ActionContext
     handler = sinon.stub()
   })
 
@@ -135,11 +137,10 @@ describe('ActionDecorator', function () {
       const ret = await decorator.handler(request, 'res', context)
 
       expect(before).to.have.been.calledWith(request)
-      expect(ret).to.deep.equal({
-        notice: {
-          message: errorMessage,
-          type: 'error',
-        },
+      expect(ret).to.have.property('notice')
+      expect(ret.notice).to.deep.equal({
+        message: errorMessage,
+        type: 'error',
       })
       expect(handler).not.to.have.been.called
     })
@@ -163,18 +164,14 @@ describe('ActionDecorator', function () {
       const ret = await decorator.handler(request, 'res', context)
 
       expect(before).to.have.been.calledWith(request)
-      expect(ret).to.deep.equal({
-        notice: {
-          message: notice.message,
-          type: 'error',
-        },
-        record: {
-          errors,
-          params: {},
-          populated: {},
-        },
-        records: [],
+      expect(ret).to.have.property('notice')
+      expect(ret.notice).to.deep.equal({
+        message: notice.message,
+        type: 'error',
       })
+      expect(ret).to.have.property('record')
+      expect(ret.record).to.have.property('errors')
+      expect(ret.record.errors).to.deep.equal(errors)
       expect(handler).not.to.have.been.called
     })
   })

--- a/src/backend/services/action-error-handler/action-error-handler.spec.ts
+++ b/src/backend/services/action-error-handler/action-error-handler.spec.ts
@@ -28,7 +28,7 @@ describe('ActionErrorHandler', function () {
     record = sinon.createStubInstance(BaseRecord) as unknown as BaseRecord
     translateMessage = sinon.stub().returns(notice.message)
     action = { name: 'myAction' } as ActionDecorator
-    context = { resource, record, currentAdmin, translateMessage, action} as ActionContext
+    context = { resource, record, currentAdmin, translateMessage, action } as ActionContext
   })
 
   afterEach(function () {
@@ -51,7 +51,7 @@ describe('ActionErrorHandler', function () {
       },
       notice,
       records: [],
-      meta: undefined
+      meta: undefined,
     })
   })
 
@@ -78,7 +78,7 @@ describe('ActionErrorHandler', function () {
         page: 0,
         direction: null,
         sortBy: null,
-      }
+      },
     })
   })
 
@@ -106,7 +106,7 @@ describe('ActionErrorHandler', function () {
         message: errorMessage,
         type: 'error',
       },
-      meta: undefined
+      meta: undefined,
     })
   })
 
@@ -133,7 +133,7 @@ describe('ActionErrorHandler', function () {
         page: 0,
         direction: null,
         sortBy: null,
-      }
+      },
     })
   })
 })

--- a/src/backend/services/action-error-handler/action-error-handler.spec.ts
+++ b/src/backend/services/action-error-handler/action-error-handler.spec.ts
@@ -9,12 +9,14 @@ import ValidationError from '../../utils/errors/validation-error'
 
 import ActionErrorHandler from './action-error-handler'
 import ForbiddenError from '../../utils/errors/forbidden-error'
+import { ActionDecorator } from '../../decorators'
 
 describe('ActionErrorHandler', function () {
   let resource: BaseResource
   let record: BaseRecord
   let translateMessage
   let context: ActionContext
+  let action: ActionDecorator
   const notice = {
     message: 'stubbed translation message',
     type: 'error',
@@ -25,7 +27,8 @@ describe('ActionErrorHandler', function () {
     resource = sinon.createStubInstance(BaseResource)
     record = sinon.createStubInstance(BaseRecord) as unknown as BaseRecord
     translateMessage = sinon.stub().returns(notice.message)
-    context = { resource, record, currentAdmin, translateMessage } as ActionContext
+    action = { name: 'myAction' } as ActionDecorator
+    context = { resource, record, currentAdmin, translateMessage, action} as ActionContext
   })
 
   afterEach(function () {
@@ -41,12 +44,41 @@ describe('ActionErrorHandler', function () {
 
     expect(ActionErrorHandler(error, context)).to.deep.equal({
       record: {
+        baseError: null,
         errors,
         params: {},
         populated: {},
       },
       notice,
       records: [],
+      meta: undefined
+    })
+  })
+
+  it('returns meta when ValidationError is thrown for the list action', function () {
+    const errors = {
+      fieldWithError: {
+        type: 'required', message: 'Field is required',
+      } }
+    const error = new ValidationError(errors)
+    action.name = 'list'
+
+    expect(ActionErrorHandler(error, context)).to.deep.equal({
+      record: {
+        baseError: null,
+        errors,
+        params: {},
+        populated: {},
+      },
+      notice,
+      records: [],
+      meta: {
+        total: 0,
+        perPage: 0,
+        page: 0,
+        direction: null,
+        sortBy: null,
+      }
     })
   })
 
@@ -63,10 +95,45 @@ describe('ActionErrorHandler', function () {
     const error = new ForbiddenError(errorMessage)
 
     expect(ActionErrorHandler(error, context)).to.deep.equal({
+      record: {
+        baseError: null,
+        errors: {},
+        params: {},
+        populated: {},
+      },
+      records: [],
       notice: {
         message: errorMessage,
         type: 'error',
       },
+      meta: undefined
+    })
+  })
+
+  it('returns meta when ForbiddenError is thrown for the list action', function () {
+    const errorMessage = 'you cannot perform this action'
+    const error = new ForbiddenError(errorMessage)
+    action.name = 'list'
+
+    expect(ActionErrorHandler(error, context)).to.deep.equal({
+      record: {
+        baseError: null,
+        errors: {},
+        params: {},
+        populated: {},
+      },
+      notice: {
+        message: errorMessage,
+        type: 'error',
+      },
+      records: [],
+      meta: {
+        total: 0,
+        perPage: 0,
+        page: 0,
+        direction: null,
+        sortBy: null,
+      }
     })
   })
 })

--- a/src/backend/services/action-error-handler/action-error-handler.ts
+++ b/src/backend/services/action-error-handler/action-error-handler.ts
@@ -14,21 +14,21 @@ const actionErrorHandler = (error: any, context: ActionContext): ActionResponse 
     let baseMessage = ''
     let baseError: RecordError | null = null
     let errors: PropertyErrors = {}
-    let meta: any = undefined
+    let meta: any
 
     if (error instanceof ValidationError) {
       baseMessage = error.baseError?.message
         || context.translateMessage('thereWereValidationErrors', resource.id())
-      baseError = error.baseError
+      baseError = error.baseError ?? null
       errors = error.propertyErrors
     } else {
       // Defaults to ForbiddenError
       baseMessage = error.baseMessage
         || context.translateMessage('anyForbiddenError', resource.id())
     }
-  
+
     // Add required meta data for the list action
-    if (action.name == 'list') {
+    if (action.name === 'list') {
       meta = {
         total: 0,
         perPage: 0,
@@ -53,7 +53,7 @@ const actionErrorHandler = (error: any, context: ActionContext): ActionResponse 
         message: baseMessage,
         type: 'error',
       },
-      meta
+      meta,
     }
   }
   throw error

--- a/src/frontend/components/spec/record-json.factory.ts
+++ b/src/frontend/components/spec/record-json.factory.ts
@@ -8,6 +8,7 @@ factory.define<RecordJSON>('RecordJSON', Object, {
     'nested.param': 'value2',
   },
   populated: {},
+  baseError: null,
   errors: {},
   id: factory.sequence('JSONRecord.id', n => `someId${n}`),
   title: factory.sequence('JSONRecord.id', n => `someTitle${n}`),

--- a/src/frontend/hooks/use-record/update-record.spec.ts
+++ b/src/frontend/hooks/use-record/update-record.spec.ts
@@ -19,6 +19,7 @@ describe('updateRecord', function () {
         id: 'someId',
       } as RecordJSON,
     },
+    baseError: null,
     errors: {},
     params: {
       email: 'john@doe.pl',
@@ -48,6 +49,7 @@ describe('updateRecord', function () {
       id,
       title: 'Adolf',
       populated: {},
+      baseError: null,
       errors: {},
       params: {
         name: 'Adolf',

--- a/src/frontend/interfaces/record-json.interface.ts
+++ b/src/frontend/interfaces/record-json.interface.ts
@@ -24,6 +24,10 @@ export interface RecordJSON {
    */
   populated: Record<string, RecordJSON | null | undefined>;
   /**
+   * Any base/overall validation error for the record
+   */
+  baseError: ErrorMessage | null;
+  /**
    * List of all validation errors
    */
   errors: Record<string, ErrorMessage>;


### PR DESCRIPTION
## Notable Changes
Added some error handling improvements to better support API based adapters, which may return validation or forbidden errors.

* Added a baseError property to the BaseRecord.
  * This allows any ValidationError baseError messages to be stored in the record and then used when generating the notice error for the Edit and New backend actions.
* Fixed the logic for handling ValidationErrors in the Delete backend actions, so it no longer requires a baseError to generate a notice error response.
  * Added new Delete backend actions test spec to validate the above change.
* Updated the default backend Action Error Handler to return all required values for displaying an error notice in the frontend for the List backend action and for ForbiddenErrors

## Testing Notes
Added and updated automated unit testing to cover the code changes.

The exception was creating test suites for edit-action.ts and new-action.ts changes.  I attempted to make new test specs for these files but couldn't work through the mocking/stubbing needed to set up the spec.

## Possible Future Improvements
Improve ValidationError and ForbiddenError handling for the Show and Deleted backend actions, which may need frontend changes as well. 

## Additional Comments
Please let me know if there's anything else I can do or should change when making PRs with your project, since I will hopefully be adding more in the future (especially around error handling).  Thank you!