### PR TITLE
fix: remove the trailing slash from the resources search path

### DIFF
--- a/src/backend/utils/router/router.ts
+++ b/src/backend/utils/router/router.ts
@@ -132,7 +132,7 @@ export const Router: RouterType = {
     action: 'bulkAction',
   }, {
     method: 'GET',
-    path: '/api/resources/{resourceId}/search/',
+    path: '/api/resources/{resourceId}/search',
     Controller: ApiController,
     action: 'search',
   }, {


### PR DESCRIPTION
Remove the trailing slash from the `/api/resources/{resourceId}/search` path to not conflict with Hapi projects using the `stripTrailingSlash` on `true`, and also to have all the paths with the same format.