### PR TITLE
fix: error in AdminJS.bundle() compatibility

### DIFF
--- a/src/adminjs.ts
+++ b/src/adminjs.ts
@@ -347,11 +347,7 @@ class AdminJS {
   public static bundle(src: string, componentName?: OverridableComponent): string {
     // eslint-disable-next-line no-plusplus
     const name = componentName ?? `Component${this.__unsafe_componentIndex++}`
-    if (componentName) {
-      this.__unsafe_staticComponentLoader.override(name, src, 'bundle')
-    } else {
-      this.__unsafe_staticComponentLoader.add(name, src, 'bundle')
-    }
+    this.__unsafe_staticComponentLoader.__unsafe_addWithoutChecks(name, src, 'bundle')
     return name
   }
 

--- a/src/backend/utils/component-loader.ts
+++ b/src/backend/utils/component-loader.ts
@@ -39,6 +39,15 @@ export class ComponentLoader {
     return name
   }
 
+  public __unsafe_addWithoutChecks(name: string, filePath: string, caller = '__unsafe_addWithoutChecks') {
+    const resolvedFilePath = ComponentLoader.resolveFilePath(filePath, caller)
+    this.components[name] = {
+      overrides: false,
+      filePath: resolvedFilePath,
+    }
+    return name
+  }
+
   public clear() {
     this.components = {}
   }


### PR DESCRIPTION
This removes add/override checks from `AdminJS.bundle()` calls so the component name argument can be used for custom components.

Previously it would try to use `loader.override()` method if the name was provided, causing an error when the name was not on the list of overridable components.