### PR TITLE
fix: feature component loader issue

### DIFF
--- a/src/adminjs.ts
+++ b/src/adminjs.ts
@@ -120,10 +120,11 @@ class AdminJS {
     this.initI18n()
 
     const { databases, resources } = this.options
-    const resourcesFactory = new ResourcesFactory(this, global.RegisteredAdapters || [])
-    this.resources = resourcesFactory.buildResources({ databases, resources })
 
     this.componentLoader = options.componentLoader ?? new ComponentLoader()
+
+    const resourcesFactory = new ResourcesFactory(this, global.RegisteredAdapters || [])
+    this.resources = resourcesFactory.buildResources({ databases, resources })
   }
 
   initI18n(): void {


### PR DESCRIPTION
The bug is caused by missing `ComponentLoader` when the features are being loaded into resources. The fix moves `ComponentLoader` initialization ahead of feature loading.