### PR TITLE
feat: replace icons library

### DIFF
--- a/src/backend/actions/action.interface.ts
+++ b/src/backend/actions/action.interface.ts
@@ -265,7 +265,7 @@ export type BuildInActions =
  * ```
  * const action = {
  *   actionType: 'record',
- *   icon: 'View',
+ *   icon: 'Eye',
  *   isVisible: true,
  *   handler: async () => {...},
  *   component: 'MyAction',
@@ -300,7 +300,7 @@ export type BuildInActions =
  *         // example of overriding existing 'new' action for
  *         // User resource.
  *         new: {
- *           icon: 'Add'
+ *           icon: 'Plus'
  *         },
  *         // Example of creating a new 'myNewAction' which will be
  *         // a resource action available for User model
@@ -429,7 +429,7 @@ export interface Action <T extends ActionResponse> {
    * ```javascript
    * new AdminJS({ resources: [{
    *   resource: Car,
-   *   options: { actions: { edit: { icon: 'Add' } } },
+   *   options: { actions: { edit: { icon: 'Plus' } } },
    * }]})
    * ```
    */

--- a/src/backend/actions/bulk-delete/bulk-delete-action.ts
+++ b/src/backend/actions/bulk-delete/bulk-delete-action.ts
@@ -13,7 +13,7 @@ export const BulkDeleteAction: Action<BulkActionResponse> = {
   name: 'bulkDelete',
   isVisible: true,
   actionType: 'bulk',
-  icon: 'Delete',
+  icon: 'Trash2',
   showInDrawer: true,
   variant: 'danger',
   /**

--- a/src/backend/actions/delete/delete-action.ts
+++ b/src/backend/actions/delete/delete-action.ts
@@ -15,7 +15,7 @@ export const DeleteAction: Action<RecordActionResponse> = {
   name: 'delete',
   isVisible: true,
   actionType: 'record',
-  icon: 'TrashCan',
+  icon: 'Trash2',
   guard: 'confirmDelete',
   component: false,
   variant: 'danger',

--- a/src/backend/actions/new/new-action.ts
+++ b/src/backend/actions/new/new-action.ts
@@ -15,7 +15,7 @@ export const NewAction: Action<RecordActionResponse> = {
   name: 'new',
   isVisible: true,
   actionType: 'resource',
-  icon: 'Add',
+  icon: 'Plus',
   showInDrawer: false,
   variant: 'primary',
   /**

--- a/src/backend/actions/show/show-action.ts
+++ b/src/backend/actions/show/show-action.ts
@@ -14,7 +14,7 @@ export const ShowAction: Action<RecordActionResponse> = {
   name: 'show',
   isVisible: true,
   actionType: 'record',
-  icon: 'Screen',
+  icon: 'Monitor',
   showInDrawer: false,
   /**
    * Responsible for returning data for given record.

--- a/src/backend/bundler/config.js
+++ b/src/backend/bundler/config.js
@@ -19,13 +19,13 @@ const external = [
   'styled-components',
   'adminjs',
   '@adminjs/design-system',
-  '@carbon/icons-react',
+  'react-feather',
 ]
 
 const globals = {
   react: 'React',
   redux: 'Redux',
-  '@carbon/icons-react': 'CarbonIcons',
+  'react-feather': 'FeatherIcons',
   'styled-components': 'styled',
   'prop-types': 'PropTypes',
   'react-dom': 'ReactDOM',

--- a/src/backend/decorators/resource/utils/get-navigation.spec.ts
+++ b/src/backend/decorators/resource/utils/get-navigation.spec.ts
@@ -58,7 +58,7 @@ describe('.getNavigation', () => {
   })
 
   it('returns empty parent with an icon when this was set in options', () => {
-    const icon = 'Car'
+    const icon = 'Activity'
     resourceOptions.navigation = { icon, name: null }
 
     expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({
@@ -69,7 +69,7 @@ describe('.getNavigation', () => {
   })
 
   it('works the same with old parent option', () => {
-    const icon = 'Car'
+    const icon = 'Activity'
     resourceOptions.parent = { icon, name: null }
 
     expect(getNavigation(resourceOptions, defaultDatabase)).to.deep.eq({

--- a/src/backend/decorators/resource/utils/get-navigation.ts
+++ b/src/backend/decorators/resource/utils/get-navigation.ts
@@ -7,22 +7,22 @@ export type DatabaseData = {
   databaseType: BaseResource['databaseType'];
 }
 
-export const DEFAULT_ICON = 'Archive'
+export const DEFAULT_ICON = 'Database'
 
 type IconMapType = {[key in SupportedDatabasesType]: string}
 
 export const getIcon = (icon?: SupportedDatabasesType | string): string => {
   const IconMap: IconMapType = {
-    MariaDB: 'Sql',
-    MySQL: 'Sql',
-    Postgres: 'Sql',
-    CockroachDB: 'Sql',
-    SQLite: 'Sql',
-    MicrosoftSQLServer: 'Sql',
-    Oracle: 'Sql',
-    SAPHana: 'CloudApp',
-    MongoDB: 'Archive',
-    other: 'Archive',
+    MariaDB: 'Database',
+    MySQL: 'Database',
+    Postgres: 'Database',
+    CockroachDB: 'Database',
+    SQLite: 'Database',
+    MicrosoftSQLServer: 'Database',
+    Oracle: 'Database',
+    SAPHana: 'Cloud',
+    MongoDB: 'FileText',
+    other: 'Database',
   }
   return (icon && IconMap[icon]) ? IconMap[icon] : DEFAULT_ICON
 }

--- a/src/frontend/components/actions/bulk-delete.tsx
+++ b/src/frontend/components/actions/bulk-delete.tsx
@@ -96,7 +96,7 @@ const BulkDelete: React.FC<ActionProps & AddNoticeProps> = (props) => {
       </DrawerContent>
       <DrawerFooter data-css={footerTag}>
         <Button variant="primary" size="lg" onClick={handleClick} disabled={loading}>
-          {loading ? (<Icon icon="Fade" spin />) : null}
+          {loading ? (<Icon icon="Loader" spin />) : null}
           {translateButton(records.length > 1 ? 'confirmRemovalMany_plural' : 'confirmRemovalMany', resource.id, { count: records.length })}
         </Button>
       </DrawerFooter>

--- a/src/frontend/components/actions/edit.tsx
+++ b/src/frontend/components/actions/edit.tsx
@@ -80,7 +80,7 @@ const Edit: FC<ActionProps> = (props) => {
       </DrawerContent>
       <DrawerFooter data-css={footerTag}>
         <Button variant="primary" size="lg" type="submit" data-css={buttonTag} data-testid="button-save" disabled={loading}>
-          {loading ? (<Icon icon="Fade" spin />) : null}
+          {loading ? (<Icon icon="Loader" spin />) : null}
           {translateButton('save', resource.id)}
         </Button>
       </DrawerFooter>

--- a/src/frontend/components/actions/new.tsx
+++ b/src/frontend/components/actions/new.tsx
@@ -84,7 +84,7 @@ const New: FC<ActionProps> = (props) => {
       </DrawerContent>
       <DrawerFooter data-css={footerTag}>
         <Button variant="primary" size="lg" type="submit" data-css={buttonTag} data-testid="button-save" disabled={loading}>
-          {loading ? (<Icon icon="Fade" spin />) : null}
+          {loading ? (<Icon icon="Loader" spin />) : null}
           {translateButton('save', resource.id)}
         </Button>
       </DrawerFooter>

--- a/src/frontend/components/app/action-header/action-header.tsx
+++ b/src/frontend/components/app/action-header/action-header.tsx
@@ -61,7 +61,7 @@ const ActionHeader: React.FC<ActionHeaderProps> = (props) => {
     actionButtons.push({
       label: translateButton('filter', resource.id),
       onClick: toggleFilter,
-      icon: 'SettingsAdjust',
+      icon: 'Sliders',
       'data-css': getResourceElementCss(resource.id, 'filter-button'),
     })
   }

--- a/src/frontend/components/app/base-action-component.tsx
+++ b/src/frontend/components/app/base-action-component.tsx
@@ -27,7 +27,7 @@ declare const AdminJS: {
  *        actions: {
  *           myNewAction: {
  *             label: 'amazing action',
- *             icon: 'Add',
+ *             icon: 'Plus',
  *             inVisible: (resource, record) => record.param('email') !== '',
  *             actionType: 'record',
  *             component: 'MyNewAction',

--- a/src/frontend/components/app/logged-in.tsx
+++ b/src/frontend/components/app/logged-in.tsx
@@ -22,7 +22,7 @@ const LoggedIn: React.FC<LoggedInProps> = (props) => {
       event.preventDefault()
       window.location.href = paths.logoutPath
     },
-    icon: 'Logout',
+    icon: 'LogOut',
   }]
   return (
     <Box flexShrink={0} data-css="logged-in">

--- a/src/frontend/components/app/records-table/no-records.tsx
+++ b/src/frontend/components/app/records-table/no-records.tsx
@@ -24,7 +24,7 @@ const NoRecordsOriginal: React.FC<NoRecordsProps> = (props) => {
       {canCreate ? (
         <ActionButton action={canCreate} resourceId={resource.id}>
           <Button variant="primary">
-            <Icon icon="Add" />
+            <Icon icon="Plus" />
             {translateButton('createFirstRecord', resource.id)}
           </Button>
         </ActionButton>

--- a/src/frontend/components/app/records-table/record-in-list.tsx
+++ b/src/frontend/components/app/records-table/record-in-list.tsx
@@ -79,7 +79,7 @@ const RecordInList: React.FC<RecordInListProps> = (props) => {
   )
 
   const buttons = [{
-    icon: 'OverflowMenuHorizontal',
+    icon: 'MoreHorizontal',
     variant: 'light' as const,
     label: undefined,
     'data-testid': 'actions-dropdown',

--- a/src/frontend/components/app/sort-link.tsx
+++ b/src/frontend/components/app/sort-link.tsx
@@ -19,7 +19,7 @@ const SortLink: React.FC<SortLinkProps> = (props) => {
 
   const query = new URLSearchParams(location.search)
   const oppositeDirection = (isActive && direction === 'asc') ? 'desc' : 'asc'
-  const sortedByIcon = `Caret${direction === 'asc' ? 'Up' : 'Down'}`
+  const sortedByIcon = `Chevron${direction === 'asc' ? 'Up' : 'Down'}`
 
   query.set('direction', oppositeDirection)
   query.set('sortBy', property.propertyPath)

--- a/src/frontend/components/property-type/array/add-new-item-translation.tsx
+++ b/src/frontend/components/property-type/array/add-new-item-translation.tsx
@@ -22,7 +22,7 @@ const AddNewItemButton: React.FC<AddNewItemButtonProps> = (props) => {
 
   return (
     <Box>
-      <Icon icon="Add" />
+      <Icon icon="Plus" />
       {label}
     </Box>
   )

--- a/src/frontend/components/property-type/array/edit.tsx
+++ b/src/frontend/components/property-type/array/edit.tsx
@@ -54,7 +54,7 @@ const ItemRenderer: React.FC<EditProps & ItemRendererProps> = (props) => {
               onClick={(event): boolean => onDelete(event, property)}
               variant="danger"
             >
-              <Icon icon="TrashCan" />
+              <Icon icon="Trash2" />
             </Button>
           </Box>
         </Box>

--- a/src/frontend/components/property-type/key-value/edit.tsx
+++ b/src/frontend/components/property-type/key-value/edit.tsx
@@ -69,7 +69,7 @@ const EditKeyValuePair: React.FC<EditKeyValuePairProps> = (props) => {
         flexGrow={0}
         flexShrink={1}
       >
-        <Icon icon="TrashCan" />
+        <Icon icon="Trash2" />
       </Button>
     </Box>
   )

--- a/src/frontend/components/property-type/password/edit.tsx
+++ b/src/frontend/components/property-type/password/edit.tsx
@@ -42,7 +42,7 @@ const Edit: React.FC<EditPropertyProps> = (props) => {
           size="icon"
           onClick={() => setIsInput(!isInput)}
         >
-          <Icon icon="View" />
+          <Icon icon="Eye" />
         </Button>
       </InputGroup>
       <FormMessage>{error && error.message}</FormMessage>

--- a/src/frontend/components/property-type/utils/property-description/property-description.tsx
+++ b/src/frontend/components/property-type/utils/property-description/property-description.tsx
@@ -18,7 +18,7 @@ const PropertyDescription: React.FC<PropertyDescriptionProps> = (props) => {
     <Box mx="sm" display="inline-flex">
       <Tooltip direction={direction} title={property.description} size="lg">
         <Box>
-          <Icon icon="Help" color="info" />
+          <Icon icon="HelpCircle" color="info" />
         </Box>
       </Tooltip>
     </Box>


### PR DESCRIPTION
BREAKING CHANGE: Carbon Icons have been replaced by Feather Icons, a lighter icons library, to reduce the bundle size of @adminjs/design-system. There are less icons and their names are often different than Carbon's. If you were using the Icon component imported from @adminjs/design-system, make sure you update icon names to their counterparts from https://feathericons.com/. You can still install other icon libraries and use them in your custom components, take note of the bundle size though.