### PR TITLE
refactor: fix <TextEdit /> bugs

### DIFF
--- a/src/frontend/components/property-type/base-property-component.tsx
+++ b/src/frontend/components/property-type/base-property-component.tsx
@@ -1,6 +1,6 @@
-import { Box } from '@adminjs/design-system'
+import { Box, Label } from '@adminjs/design-system'
 import { ReactComponentLike } from 'prop-types'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 
 import ErrorBoundary from '../app/error-boundary'
 
@@ -68,6 +68,8 @@ const BasePropertyComponent: React.FC<BasePropertyComponentProps> = (props) => {
     // path either index (for array) or subProperty name.
     path: (baseProperty as PropertyJSON).path || baseProperty.propertyPath,
   }), [baseProperty])
+  const propValue = record?.params?.[property.path]
+  const [originalValue] = useState(propValue)
 
   const testId = `property-${where}-${property.path}`
   const contentTag = getActionElementCss(resource.id, where, property.path)
@@ -149,6 +151,17 @@ const BasePropertyComponent: React.FC<BasePropertyComponentProps> = (props) => {
           onChange={onChange}
           where={where}
         />
+        {propValue !== originalValue && (
+          <Label
+            variant="light"
+            inline
+            onClick={() => {
+              onChange!(property.path, originalValue)
+            }}
+          >
+            Reset
+          </Label>
+        )}
       </Box>
     </ErrorBoundary>
   )

--- a/src/frontend/components/property-type/default-type/edit.tsx
+++ b/src/frontend/components/property-type/default-type/edit.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import React, { FC, useState, memo, useEffect } from 'react'
+import React, { FC, memo } from 'react'
 import { Input, FormMessage, FormGroup, Select } from '@adminjs/design-system'
 
 import { EditPropertyProps } from '../base-property-props'
@@ -43,26 +43,19 @@ const SelectEdit: FC<CombinedProps> = (props) => {
 
 const TextEdit: FC<CombinedProps> = (props) => {
   const { property, record, onChange } = props
-  const propValue = record.params?.[property.path] ?? ''
-  const [value, setValue] = useState(propValue)
-
-  useEffect(() => {
-    if (value !== propValue) {
-      setValue(propValue)
-    }
-  }, [propValue])
+  const propValue = record.params[property.path]
 
   return (
     <Input
       id={property.path}
       name={property.path}
       required={property.isRequired}
-      onChange={(e) => setValue(e.target.value)}
-      onBlur={() => onChange(property.path, value)}
-      // handle clicking ENTER
-      onKeyDown={(e) => e.keyCode === 13 && onChange(property.path, value)}
-      value={value}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(property.path, e.target.value)
+      }}
+      value={propValue ?? ''}
       disabled={property.isDisabled}
+      placeholder={propValue === null ? '<null>' : undefined}
       {...property.props}
     />
   )


### PR DESCRIPTION
`<TextEdit />` currently has a few issue, and it's something that causes a lot of issues for me

1. If the user has a field which the value of is currently `null`, there is no way for the user to know null vs blank.
2. If the current field is `null` and during an edit the user focuses the field but makes no changes, during a save the client will tell the server that the value is `""` for strings or `0` for numbers. This is an issue where an edit is made without the user even knowing it happened, this can cause validation errors and/or other issues.
3. The component is overly complex and uses odd event listeners like `onBlur` and `onKeyDown` which is unnecessary.
4. The `useEffect` seemingly does nothing 


This PR contains a fix to `<TextEdit />`

But in addition has a feature proposal that I haven't ironed out yet. I propose to add some form of a reset for the field, it would make it clear to the user that the field has been edited. I have the functionality working, but the styling is pretty bad.

This video showcases the fix for `<TextEdit />` as you are able to focus and unfocus without value change.
The "Reset" text will only show for a field that has been modified. 

The "Price per" field is actually not fixed since currency type doesn't use the same `<TextEdit />` component, so the old behavior is evident there.

![recording](https://user-images.githubusercontent.com/1350342/209431644-f570635c-da0c-4c95-8489-c716710db03d.gif)