### PR TITLE
feat: include context when calling adapter functions

### DIFF
--- a/src/backend/actions/bulk-delete/bulk-delete-action.ts
+++ b/src/backend/actions/bulk-delete/bulk-delete-action.ts
@@ -27,7 +27,7 @@ export const BulkDeleteAction: Action<BulkActionResponse> = {
    * @memberof module:BulkDeleteAction
    */
   handler: async (request, response, context) => {
-    const { records, resource, h, translateMessage } = context
+    const { records, resource, currentAdmin, h, translateMessage } = context
 
     if (!records || !records.length) {
       throw new NotFoundError('no records were selected.', 'Action#handler')
@@ -39,7 +39,7 @@ export const BulkDeleteAction: Action<BulkActionResponse> = {
       }
     }
     if (request.method === 'post') {
-      await Promise.all(records.map((record) => resource.delete(record.id())))
+      await Promise.all(records.map((record) => resource.delete(record.id(), currentAdmin)))
       return {
         records: records.map((record) => record.toJSON(context.currentAdmin)),
         notice: {

--- a/src/backend/actions/bulk-delete/bulk-delete-action.ts
+++ b/src/backend/actions/bulk-delete/bulk-delete-action.ts
@@ -27,7 +27,7 @@ export const BulkDeleteAction: Action<BulkActionResponse> = {
    * @memberof module:BulkDeleteAction
    */
   handler: async (request, response, context) => {
-    const { records, resource, currentAdmin, h, translateMessage } = context
+    const { records, resource, h, translateMessage } = context
 
     if (!records || !records.length) {
       throw new NotFoundError('no records were selected.', 'Action#handler')
@@ -39,7 +39,7 @@ export const BulkDeleteAction: Action<BulkActionResponse> = {
       }
     }
     if (request.method === 'post') {
-      await Promise.all(records.map((record) => resource.delete(record.id(), currentAdmin)))
+      await Promise.all(records.map((record) => resource.delete(record.id(), context)))
       return {
         records: records.map((record) => record.toJSON(context.currentAdmin)),
         notice: {

--- a/src/backend/actions/delete/delete-action.ts
+++ b/src/backend/actions/delete/delete-action.ts
@@ -28,15 +28,15 @@ export const DeleteAction: Action<RecordActionResponse> = {
    * @implements ActionHandler
    * @memberof module:DeleteAction
    */
-  handler: async (request, response, data) => {
-    const { record, resource, currentAdmin, h, translateMessage } = data
+  handler: async (request, response, context) => {
+    const { record, resource, currentAdmin, h, translateMessage } = context
     if (!request.params.recordId || !record) {
       throw new NotFoundError([
         'You have to pass "recordId" to Delete Action',
       ].join('\n'), 'Action#handler')
     }
     try {
-      await resource.delete(request.params.recordId, currentAdmin)
+      await resource.delete(request.params.recordId, context)
     } catch (error) {
       if (error instanceof ValidationError) {
         const baseMessage = error.baseError?.message

--- a/src/backend/actions/delete/delete-action.ts
+++ b/src/backend/actions/delete/delete-action.ts
@@ -36,7 +36,7 @@ export const DeleteAction: Action<RecordActionResponse> = {
       ].join('\n'), 'Action#handler')
     }
     try {
-      await resource.delete(request.params.recordId)
+      await resource.delete(request.params.recordId, currentAdmin)
     } catch (error) {
       if (error instanceof ValidationError) {
         const baseMessage = error.baseError?.message

--- a/src/backend/actions/edit/edit-action.ts
+++ b/src/backend/actions/edit/edit-action.ts
@@ -42,7 +42,7 @@ export const EditAction: Action<RecordActionResponse> = {
 
     const params = paramConverter.prepareParams(request.payload ?? {}, resource)
     const newRecord = await record.update(params, context)
-    const [populatedRecord] = await populator([newRecord])
+    const [populatedRecord] = await populator([newRecord], context)
 
     // eslint-disable-next-line no-param-reassign
     context.record = populatedRecord

--- a/src/backend/actions/edit/edit-action.ts
+++ b/src/backend/actions/edit/edit-action.ts
@@ -41,7 +41,7 @@ export const EditAction: Action<RecordActionResponse> = {
     }
 
     const params = paramConverter.prepareParams(request.payload ?? {}, resource)
-    const newRecord = await record.update(params, currentAdmin)
+    const newRecord = await record.update(params, context)
     const [populatedRecord] = await populator([newRecord])
 
     // eslint-disable-next-line no-param-reassign

--- a/src/backend/actions/edit/edit-action.ts
+++ b/src/backend/actions/edit/edit-action.ts
@@ -41,7 +41,7 @@ export const EditAction: Action<RecordActionResponse> = {
     }
 
     const params = paramConverter.prepareParams(request.payload ?? {}, resource)
-    const newRecord = await record.update(params)
+    const newRecord = await record.update(params, currentAdmin)
     const [populatedRecord] = await populator([newRecord])
 
     // eslint-disable-next-line no-param-reassign

--- a/src/backend/actions/list/list-action.ts
+++ b/src/backend/actions/list/list-action.ts
@@ -1,5 +1,5 @@
 import { flat } from '../../../utils/flat'
-import { Action, ActionResponse, ActionQueryParameters } from '../action.interface'
+import { Action, ActionQueryParameters, ActionResponse } from '../action.interface'
 import sortSetter from '../../services/sort-setter/sort-setter'
 import Filter from '../../utils/filter/filter'
 import populator from '../../utils/populator/populator'
@@ -56,17 +56,18 @@ export const ListAction: Action<ListActionResponse> = {
 
     const filter = await new Filter(filters, resource).populate()
 
+    const { currentAdmin } = context
     const records = await resource.find(filter, {
       limit: perPage,
       offset: (page - 1) * perPage,
       sort,
-    })
+    }, currentAdmin)
     const populatedRecords = await populator(records)
 
     // eslint-disable-next-line no-param-reassign
     context.records = populatedRecords
 
-    const total = await resource.count(filter)
+    const total = await resource.count(filter, currentAdmin)
     return {
       meta: {
         total,
@@ -75,7 +76,7 @@ export const ListAction: Action<ListActionResponse> = {
         direction: sort?.direction,
         sortBy: sort?.sortBy,
       },
-      records: populatedRecords.map((r) => r.toJSON(context.currentAdmin)),
+      records: populatedRecords.map((r) => r.toJSON(currentAdmin)),
     }
   },
 }

--- a/src/backend/actions/list/list-action.ts
+++ b/src/backend/actions/list/list-action.ts
@@ -54,7 +54,7 @@ export const ListAction: Action<ListActionResponse> = {
       )
     }
 
-    const filter = await new Filter(filters, resource).populate()
+    const filter = await new Filter(filters, resource).populate(context)
 
     const { currentAdmin } = context
     const records = await resource.find(filter, {
@@ -62,7 +62,7 @@ export const ListAction: Action<ListActionResponse> = {
       offset: (page - 1) * perPage,
       sort,
     }, context)
-    const populatedRecords = await populator(records)
+    const populatedRecords = await populator(records, context)
 
     // eslint-disable-next-line no-param-reassign
     context.records = populatedRecords

--- a/src/backend/actions/list/list-action.ts
+++ b/src/backend/actions/list/list-action.ts
@@ -61,13 +61,13 @@ export const ListAction: Action<ListActionResponse> = {
       limit: perPage,
       offset: (page - 1) * perPage,
       sort,
-    }, currentAdmin)
+    }, context)
     const populatedRecords = await populator(records)
 
     // eslint-disable-next-line no-param-reassign
     context.records = populatedRecords
 
-    const total = await resource.count(filter, currentAdmin)
+    const total = await resource.count(filter, context)
     return {
       meta: {
         total,

--- a/src/backend/actions/new/new-action.ts
+++ b/src/backend/actions/new/new-action.ts
@@ -35,7 +35,7 @@ export const NewAction: Action<RecordActionResponse> = {
       let record = await resource.build(params)
 
       record = await record.create(context)
-      const [populatedRecord] = await populator([record])
+      const [populatedRecord] = await populator([record], context)
 
       // eslint-disable-next-line no-param-reassign
       context.record = populatedRecord

--- a/src/backend/actions/new/new-action.ts
+++ b/src/backend/actions/new/new-action.ts
@@ -34,7 +34,7 @@ export const NewAction: Action<RecordActionResponse> = {
 
       let record = await resource.build(params)
 
-      record = await record.create(currentAdmin)
+      record = await record.create(context)
       const [populatedRecord] = await populator([record])
 
       // eslint-disable-next-line no-param-reassign

--- a/src/backend/actions/new/new-action.ts
+++ b/src/backend/actions/new/new-action.ts
@@ -34,7 +34,7 @@ export const NewAction: Action<RecordActionResponse> = {
 
       let record = await resource.build(params)
 
-      record = await record.create()
+      record = await record.create(currentAdmin)
       const [populatedRecord] = await populator([record])
 
       // eslint-disable-next-line no-param-reassign

--- a/src/backend/actions/search/search-action.ts
+++ b/src/backend/actions/search/search-action.ts
@@ -26,8 +26,8 @@ export const SearchAction: Action<SearchActionResponse> = {
    * @return  {Promise<SearchResponse>}  populated record
    * @implements ActionHandler
    */
-  handler: async (request, response, data) => {
-    const { currentAdmin, resource } = data
+  handler: async (request, response, context) => {
+    const { currentAdmin, resource } = context
     const { query } = request
 
     const decorated = resource.decorate()
@@ -56,7 +56,7 @@ export const SearchAction: Action<SearchActionResponse> = {
         sortBy,
         direction,
       },
-    }, currentAdmin)
+    }, context)
 
     return {
       records: records.map((record) => record.toJSON(currentAdmin)),

--- a/src/backend/actions/search/search-action.ts
+++ b/src/backend/actions/search/search-action.ts
@@ -56,7 +56,7 @@ export const SearchAction: Action<SearchActionResponse> = {
         sortBy,
         direction,
       },
-    })
+    }, currentAdmin)
 
     return {
       records: records.map((record) => record.toJSON(currentAdmin)),

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -133,10 +133,10 @@ class BaseRecord {
    * @param  {object} params all field with values which has to be updated
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async update(params): Promise<BaseRecord> {
+  async update(params, currentAdmin?: CurrentAdmin): Promise<BaseRecord> {
     try {
       this.storeParams(params)
-      const returnedParams = await this.resource.update(this.id(), params)
+      const returnedParams = await this.resource.update(this.id(), params, currentAdmin)
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {
@@ -192,11 +192,13 @@ class BaseRecord {
    *
    * When validation error occurs it stores that to {@link BaseResource#errors}
    *
+   * @param  {CurrentAdmin?}           currentAdmin
+   *
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async create(): Promise<BaseRecord> {
+  async create(currentAdmin?:CurrentAdmin): Promise<BaseRecord> {
     try {
-      const returnedParams = await this.resource.create(this.params)
+      const returnedParams = await this.resource.create(this.params, currentAdmin)
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -132,7 +132,7 @@ class BaseRecord {
    * When validation error occurs it stores that to {@link BaseResource.errors}
    *
    * @param  {object} params all field with values which has to be updated
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<BaseRecord>}        given record (this)
    */
   async update(params, context?: ActionContext): Promise<BaseRecord> {
@@ -161,7 +161,7 @@ class BaseRecord {
    * {@link BaseResource#create} or {@link BaseResource#update} methods.
    *
    * When validation error occurs it stores that to {@link BaseResource#errors}
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<BaseRecord>}        given record (this)
    */
   async save(context?: ActionContext): Promise<BaseRecord> {
@@ -196,7 +196,7 @@ class BaseRecord {
    *
    *
    * @return {Promise<BaseRecord>}        given record (this)
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    */
   async create(context?: ActionContext): Promise<BaseRecord> {
     try {

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -5,6 +5,7 @@ import ValidationError, { PropertyErrors } from '../../utils/errors/validation-e
 import RecordError from '../../utils/errors/record-error'
 import { RecordJSON } from '../../../frontend/interfaces'
 import { CurrentAdmin } from '../../../current-admin.interface'
+import { ActionContext } from '../../actions'
 
 /**
  * Representation of an particular ORM/ODM Record in given Resource in AdminJS
@@ -131,12 +132,13 @@ class BaseRecord {
    * When validation error occurs it stores that to {@link BaseResource.errors}
    *
    * @param  {object} params all field with values which has to be updated
+   * @param  {ActionContext}           context
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async update(params, currentAdmin?: CurrentAdmin): Promise<BaseRecord> {
+  async update(params, context?: ActionContext): Promise<BaseRecord> {
     try {
       this.storeParams(params)
-      const returnedParams = await this.resource.update(this.id(), params, currentAdmin)
+      const returnedParams = await this.resource.update(this.id(), params, context)
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {
@@ -192,13 +194,13 @@ class BaseRecord {
    *
    * When validation error occurs it stores that to {@link BaseResource#errors}
    *
-   * @param  {CurrentAdmin?}           currentAdmin
    *
    * @return {Promise<BaseRecord>}        given record (this)
+   * @param  {ActionContext}           context
    */
-  async create(currentAdmin?:CurrentAdmin): Promise<BaseRecord> {
+  async create(context?: ActionContext): Promise<BaseRecord> {
     try {
-      const returnedParams = await this.resource.create(this.params, currentAdmin)
+      const returnedParams = await this.resource.create(this.params, context)
       this.storeParams(returnedParams)
     } catch (e) {
       if (e instanceof ValidationError) {

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -135,7 +135,7 @@ class BaseRecord {
    * @param  {ActionContext}           context
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async update(params, context: ActionContext): Promise<BaseRecord> {
+  async update(params, context?: ActionContext): Promise<BaseRecord> {
     try {
       this.storeParams(params)
       const returnedParams = await this.resource.update(this.id(), params, context)
@@ -164,7 +164,7 @@ class BaseRecord {
    * @param  {ActionContext}           context
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async save(context: ActionContext): Promise<BaseRecord> {
+  async save(context?: ActionContext): Promise<BaseRecord> {
     try {
       let returnedParams
       if (this.id()) {
@@ -198,7 +198,7 @@ class BaseRecord {
    * @return {Promise<BaseRecord>}        given record (this)
    * @param  {ActionContext}           context
    */
-  async create(context: ActionContext): Promise<BaseRecord> {
+  async create(context?: ActionContext): Promise<BaseRecord> {
     try {
       const returnedParams = await this.resource.create(this.params, context)
       this.storeParams(returnedParams)

--- a/src/backend/adapters/record/base-record.ts
+++ b/src/backend/adapters/record/base-record.ts
@@ -135,7 +135,7 @@ class BaseRecord {
    * @param  {ActionContext}           context
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async update(params, context?: ActionContext): Promise<BaseRecord> {
+  async update(params, context: ActionContext): Promise<BaseRecord> {
     try {
       this.storeParams(params)
       const returnedParams = await this.resource.update(this.id(), params, context)
@@ -161,16 +161,16 @@ class BaseRecord {
    * {@link BaseResource#create} or {@link BaseResource#update} methods.
    *
    * When validation error occurs it stores that to {@link BaseResource#errors}
-   *
+   * @param  {ActionContext}           context
    * @return {Promise<BaseRecord>}        given record (this)
    */
-  async save(): Promise<BaseRecord> {
+  async save(context: ActionContext): Promise<BaseRecord> {
     try {
       let returnedParams
       if (this.id()) {
-        returnedParams = await this.resource.update(this.id(), this.params)
+        returnedParams = await this.resource.update(this.id(), this.params, context)
       } else {
-        returnedParams = await this.resource.create(this.params)
+        returnedParams = await this.resource.create(this.params, context)
       }
       this.storeParams(returnedParams)
     } catch (e) {
@@ -198,7 +198,7 @@ class BaseRecord {
    * @return {Promise<BaseRecord>}        given record (this)
    * @param  {ActionContext}           context
    */
-  async create(context?: ActionContext): Promise<BaseRecord> {
+  async create(context: ActionContext): Promise<BaseRecord> {
     try {
       const returnedParams = await this.resource.create(this.params, context)
       this.storeParams(returnedParams)

--- a/src/backend/adapters/resource/base-resource.ts
+++ b/src/backend/adapters/resource/base-resource.ts
@@ -117,7 +117,7 @@ class BaseResource {
   /**
    * Returns number of elements for given resource by including filters
    * @param  {Filter} filter        represents what data should be included
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<Number>}
    * @abstract
    */
@@ -135,7 +135,7 @@ class BaseResource {
    * @param  {Object} [options.sort]                   sort
    * @param  {Number} [options.sort.sortBy]            sortable field
    * @param  {Number} [options.sort.direction]         either asc or desc
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<BaseRecord[]>}                          list of records
    * @abstract
    * @example
@@ -160,7 +160,7 @@ class BaseResource {
    * Finds one Record in the Resource by its id
    *
    * @param  {String} id      uniq id of the Resource Record
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<BaseRecord> | null}   record
    * @abstract
    */
@@ -172,7 +172,7 @@ class BaseResource {
    * Finds many records based on the resource ids
    *
    * @param   {Array<string>}          ids list of ids to find
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    *
    * @return  {Promise<Array<BaseRecord>>} records
    */
@@ -200,7 +200,7 @@ class BaseResource {
    * Creates new record
    *
    * @param  {Record<string, any>}     params
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
@@ -215,7 +215,7 @@ class BaseResource {
    *
    * @param  {String} id               uniq id of the Resource Record
    * @param  {Record<string, any>}     params
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
@@ -230,7 +230,7 @@ class BaseResource {
    * Delete given record by id
    *
    * @param  {String | Number}           id id of the Record
-   * @param  {ActionContext}           context
+   * @param  {ActionContext}           [context]
    * @throws {ValidationError}           If there are validation errors it should be thrown
    * @abstract
    */

--- a/src/backend/adapters/resource/base-resource.ts
+++ b/src/backend/adapters/resource/base-resource.ts
@@ -7,6 +7,7 @@ import { BaseProperty, BaseRecord, ParamsType } from '..'
 import { NotImplementedError, Filter } from '../../utils'
 import { ResourceOptions, ResourceDecorator } from '../../decorators'
 import AdminJS from '../../../adminjs'
+import { CurrentAdmin } from '../../../current-admin.interface'
 
 /**
  * Representation of a ORM Resource in AdminJS. Visually resource is a list item in the sidebar.
@@ -116,23 +117,25 @@ class BaseResource {
   /**
    * Returns number of elements for given resource by including filters
    * @param  {Filter} filter        represents what data should be included
+   * @param  {CurrentAdmin}           currentAdmin
    * @return {Promise<Number>}
    * @abstract
    */
-  async count(filter: Filter): Promise<number> {
+  async count(filter: Filter, currentAdmin?: CurrentAdmin): Promise<number> {
     throw new NotImplementedError('BaseResource#count')
   }
 
   /**
    * Returns actual records for given resource
    *
-   * @param  {Filter} filters                        what data should be included
+   * @param  {Filter} filter                        what data should be included
    * @param  {Object} options
    * @param  {Number} [options.limit]                  how many records should be taken
    * @param  {Number} [options.offset]                 offset
    * @param  {Object} [options.sort]                   sort
    * @param  {Number} [options.sort.sortBy]            sortable field
    * @param  {Number} [options.sort.direction]         either asc or desc
+   * @param  {CurrentAdmin}           currentAdmin
    * @return {Promise<BaseRecord[]>}                          list of records
    * @abstract
    * @example
@@ -149,7 +152,7 @@ class BaseResource {
       sortBy?: string;
       direction?: 'asc' | 'desc';
     };
-  }): Promise<Array<BaseRecord>> {
+  }, currentAdmin?: CurrentAdmin): Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#find')
   }
 
@@ -157,21 +160,24 @@ class BaseResource {
    * Finds one Record in the Resource by its id
    *
    * @param  {String} id      uniq id of the Resource Record
+   * @param  {CurrentAdmin?}           currentAdmin
    * @return {Promise<BaseRecord> | null}   record
    * @abstract
    */
-  async findOne(id: string): Promise<BaseRecord | null> {
+  async findOne(id: string, currentAdmin?: CurrentAdmin): Promise<BaseRecord | null> {
     throw new NotImplementedError('BaseResource#findOne')
   }
 
   /**
    * Finds many records based on the resource ids
    *
-   * @param   {Array<string>}              list of ids to find
+   * @param   {Array<string>}          ids list of ids to find
+   * @param  {CurrentAdmin?}           currentAdmin
    *
    * @return  {Promise<Array<BaseRecord>>} records
    */
-  async findMany(ids: Array<string | number>): Promise<Array<BaseRecord>> {
+  async findMany(ids: Array<string | number>, currentAdmin?: CurrentAdmin):
+    Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#findMany')
   }
 
@@ -194,26 +200,29 @@ class BaseResource {
    * Creates new record
    *
    * @param  {Record<string, any>}     params
+   * @param  {CurrentAdmin?}           currentAdmin
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async create(params: Record<string, any>): Promise<ParamsType> {
+  async create(params: Record<string, any>, currentAdmin?: CurrentAdmin): Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#create')
   }
 
   /**
-   * Updates an the record.
+   * Updates the record.
    *
    * @param  {String} id               uniq id of the Resource Record
    * @param  {Record<string, any>}     params
+   * @param  {CurrentAdmin}           currentAdmin
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async update(id: string, params: Record<string, any>): Promise<ParamsType> {
+  async update(id: string, params: Record<string, any>, currentAdmin?: CurrentAdmin)
+  : Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#update')
   }
 
@@ -221,10 +230,11 @@ class BaseResource {
    * Delete given record by id
    *
    * @param  {String | Number}           id id of the Record
+   * @param  {CurrentAdmin}           currentAdmin
    * @throws {ValidationError}           If there are validation errors it should be thrown
    * @abstract
    */
-  async delete(id: string): Promise<void> {
+  async delete(id: string, currentAdmin?: CurrentAdmin): Promise<void> {
     throw new NotImplementedError('BaseResource#delete')
   }
 

--- a/src/backend/adapters/resource/base-resource.ts
+++ b/src/backend/adapters/resource/base-resource.ts
@@ -121,7 +121,7 @@ class BaseResource {
    * @return {Promise<Number>}
    * @abstract
    */
-  async count(filter: Filter, context: ActionContext): Promise<number> {
+  async count(filter: Filter, context?: ActionContext): Promise<number> {
     throw new NotImplementedError('BaseResource#count')
   }
 
@@ -152,7 +152,7 @@ class BaseResource {
       sortBy?: string;
       direction?: 'asc' | 'desc';
     };
-  }, context: ActionContext): Promise<Array<BaseRecord>> {
+  }, context?: ActionContext): Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#find')
   }
 
@@ -164,7 +164,7 @@ class BaseResource {
    * @return {Promise<BaseRecord> | null}   record
    * @abstract
    */
-  async findOne(id: string, context: ActionContext): Promise<BaseRecord | null> {
+  async findOne(id: string, context?: ActionContext): Promise<BaseRecord | null> {
     throw new NotImplementedError('BaseResource#findOne')
   }
 
@@ -176,7 +176,7 @@ class BaseResource {
    *
    * @return  {Promise<Array<BaseRecord>>} records
    */
-  async findMany(ids: Array<string | number>, context: ActionContext):
+  async findMany(ids: Array<string | number>, context?: ActionContext):
     Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#findMany')
   }
@@ -206,7 +206,7 @@ class BaseResource {
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async create(params: Record<string, any>, context: ActionContext): Promise<ParamsType> {
+  async create(params: Record<string, any>, context?: ActionContext): Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#create')
   }
 
@@ -221,7 +221,7 @@ class BaseResource {
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async update(id: string, params: Record<string, any>, context: ActionContext)
+  async update(id: string, params: Record<string, any>, context?: ActionContext)
   : Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#update')
   }
@@ -234,7 +234,7 @@ class BaseResource {
    * @throws {ValidationError}           If there are validation errors it should be thrown
    * @abstract
    */
-  async delete(id: string, context: ActionContext): Promise<void> {
+  async delete(id: string, context?: ActionContext): Promise<void> {
     throw new NotImplementedError('BaseResource#delete')
   }
 

--- a/src/backend/adapters/resource/base-resource.ts
+++ b/src/backend/adapters/resource/base-resource.ts
@@ -7,7 +7,7 @@ import { BaseProperty, BaseRecord, ParamsType } from '..'
 import { NotImplementedError, Filter } from '../../utils'
 import { ResourceOptions, ResourceDecorator } from '../../decorators'
 import AdminJS from '../../../adminjs'
-import { CurrentAdmin } from '../../../current-admin.interface'
+import { ActionContext } from '../../actions'
 
 /**
  * Representation of a ORM Resource in AdminJS. Visually resource is a list item in the sidebar.
@@ -117,11 +117,11 @@ class BaseResource {
   /**
    * Returns number of elements for given resource by including filters
    * @param  {Filter} filter        represents what data should be included
-   * @param  {CurrentAdmin}           currentAdmin
+   * @param  {ActionContext}           context
    * @return {Promise<Number>}
    * @abstract
    */
-  async count(filter: Filter, currentAdmin?: CurrentAdmin): Promise<number> {
+  async count(filter: Filter, context?: ActionContext): Promise<number> {
     throw new NotImplementedError('BaseResource#count')
   }
 
@@ -135,7 +135,7 @@ class BaseResource {
    * @param  {Object} [options.sort]                   sort
    * @param  {Number} [options.sort.sortBy]            sortable field
    * @param  {Number} [options.sort.direction]         either asc or desc
-   * @param  {CurrentAdmin}           currentAdmin
+   * @param  {ActionContext}           context
    * @return {Promise<BaseRecord[]>}                          list of records
    * @abstract
    * @example
@@ -152,7 +152,7 @@ class BaseResource {
       sortBy?: string;
       direction?: 'asc' | 'desc';
     };
-  }, currentAdmin?: CurrentAdmin): Promise<Array<BaseRecord>> {
+  }, context?: ActionContext): Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#find')
   }
 
@@ -160,11 +160,11 @@ class BaseResource {
    * Finds one Record in the Resource by its id
    *
    * @param  {String} id      uniq id of the Resource Record
-   * @param  {CurrentAdmin?}           currentAdmin
+   * @param  {ActionContext?}           context
    * @return {Promise<BaseRecord> | null}   record
    * @abstract
    */
-  async findOne(id: string, currentAdmin?: CurrentAdmin): Promise<BaseRecord | null> {
+  async findOne(id: string, context?: ActionContext): Promise<BaseRecord | null> {
     throw new NotImplementedError('BaseResource#findOne')
   }
 
@@ -172,11 +172,11 @@ class BaseResource {
    * Finds many records based on the resource ids
    *
    * @param   {Array<string>}          ids list of ids to find
-   * @param  {CurrentAdmin?}           currentAdmin
+   * @param  {ActionContext?}           context
    *
    * @return  {Promise<Array<BaseRecord>>} records
    */
-  async findMany(ids: Array<string | number>, currentAdmin?: CurrentAdmin):
+  async findMany(ids: Array<string | number>, context?: ActionContext):
     Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#findMany')
   }
@@ -200,13 +200,13 @@ class BaseResource {
    * Creates new record
    *
    * @param  {Record<string, any>}     params
-   * @param  {CurrentAdmin?}           currentAdmin
+   * @param  {ActionContext?}           context
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async create(params: Record<string, any>, currentAdmin?: CurrentAdmin): Promise<ParamsType> {
+  async create(params: Record<string, any>, context?: ActionContext): Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#create')
   }
 
@@ -215,13 +215,13 @@ class BaseResource {
    *
    * @param  {String} id               uniq id of the Resource Record
    * @param  {Record<string, any>}     params
-   * @param  {CurrentAdmin}           currentAdmin
+   * @param  {ActionContext}           context
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async update(id: string, params: Record<string, any>, currentAdmin?: CurrentAdmin)
+  async update(id: string, params: Record<string, any>, context?: ActionContext)
   : Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#update')
   }
@@ -230,11 +230,11 @@ class BaseResource {
    * Delete given record by id
    *
    * @param  {String | Number}           id id of the Record
-   * @param  {CurrentAdmin}           currentAdmin
+   * @param  {ActionContext}           context
    * @throws {ValidationError}           If there are validation errors it should be thrown
    * @abstract
    */
-  async delete(id: string, currentAdmin?: CurrentAdmin): Promise<void> {
+  async delete(id: string, context?: ActionContext): Promise<void> {
     throw new NotImplementedError('BaseResource#delete')
   }
 

--- a/src/backend/adapters/resource/base-resource.ts
+++ b/src/backend/adapters/resource/base-resource.ts
@@ -121,7 +121,7 @@ class BaseResource {
    * @return {Promise<Number>}
    * @abstract
    */
-  async count(filter: Filter, context?: ActionContext): Promise<number> {
+  async count(filter: Filter, context: ActionContext): Promise<number> {
     throw new NotImplementedError('BaseResource#count')
   }
 
@@ -152,7 +152,7 @@ class BaseResource {
       sortBy?: string;
       direction?: 'asc' | 'desc';
     };
-  }, context?: ActionContext): Promise<Array<BaseRecord>> {
+  }, context: ActionContext): Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#find')
   }
 
@@ -160,11 +160,11 @@ class BaseResource {
    * Finds one Record in the Resource by its id
    *
    * @param  {String} id      uniq id of the Resource Record
-   * @param  {ActionContext?}           context
+   * @param  {ActionContext}           context
    * @return {Promise<BaseRecord> | null}   record
    * @abstract
    */
-  async findOne(id: string, context?: ActionContext): Promise<BaseRecord | null> {
+  async findOne(id: string, context: ActionContext): Promise<BaseRecord | null> {
     throw new NotImplementedError('BaseResource#findOne')
   }
 
@@ -172,11 +172,11 @@ class BaseResource {
    * Finds many records based on the resource ids
    *
    * @param   {Array<string>}          ids list of ids to find
-   * @param  {ActionContext?}           context
+   * @param  {ActionContext}           context
    *
    * @return  {Promise<Array<BaseRecord>>} records
    */
-  async findMany(ids: Array<string | number>, context?: ActionContext):
+  async findMany(ids: Array<string | number>, context: ActionContext):
     Promise<Array<BaseRecord>> {
     throw new NotImplementedError('BaseResource#findMany')
   }
@@ -200,13 +200,13 @@ class BaseResource {
    * Creates new record
    *
    * @param  {Record<string, any>}     params
-   * @param  {ActionContext?}           context
+   * @param  {ActionContext}           context
    * @return {Promise<Object>}         created record converted to raw Object which
    *                                   can be used to initiate new {@link BaseRecord} instance
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async create(params: Record<string, any>, context?: ActionContext): Promise<ParamsType> {
+  async create(params: Record<string, any>, context: ActionContext): Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#create')
   }
 
@@ -221,7 +221,7 @@ class BaseResource {
    * @throws {ValidationError}         If there are validation errors it should be thrown
    * @abstract
    */
-  async update(id: string, params: Record<string, any>, context?: ActionContext)
+  async update(id: string, params: Record<string, any>, context: ActionContext)
   : Promise<ParamsType> {
     throw new NotImplementedError('BaseResource#update')
   }
@@ -234,7 +234,7 @@ class BaseResource {
    * @throws {ValidationError}           If there are validation errors it should be thrown
    * @abstract
    */
-  async delete(id: string, context?: ActionContext): Promise<void> {
+  async delete(id: string, context: ActionContext): Promise<void> {
     throw new NotImplementedError('BaseResource#delete')
   }
 

--- a/src/backend/controllers/api-controller.ts
+++ b/src/backend/controllers/api-controller.ts
@@ -156,7 +156,7 @@ class ApiController {
       return invalidRecordError as RecordActionResponse
     }
 
-    let record = await actionContext.resource.findOne(recordId)
+    let record = await actionContext.resource.findOne(recordId, actionContext)
 
     if (!record) {
       const missingRecordError = actionErrorHandler(
@@ -169,7 +169,7 @@ class ApiController {
       return missingRecordError as RecordActionResponse
     }
 
-    [record] = await populator([record])
+    [record] = await populator([record], actionContext)
 
     actionContext.record = record
     const jsonWithRecord = await actionContext.action.handler(request, response, actionContext)
@@ -213,14 +213,14 @@ class ApiController {
       ].join('\n'), 'Action#handler')
     }
 
-    let records = await actionContext.resource.findMany(recordIds.split(','))
+    let records = await actionContext.resource.findMany(recordIds.split(','), actionContext)
 
     if (!records || !records.length) {
       throw new NotFoundError([
         `record with given id: "${recordIds}" cannot be found in resource "${resourceId}"`,
       ].join('\n'), 'Action#handler')
     }
-    records = await populator(records)
+    records = await populator(records, actionContext)
     const jsonWithRecord = await actionContext.action.handler(request, response, { ...actionContext, records })
 
     if (jsonWithRecord && jsonWithRecord.records) {

--- a/src/backend/utils/filter/filter.ts
+++ b/src/backend/utils/filter/filter.ts
@@ -2,6 +2,7 @@ import { flat } from '../../../utils/flat'
 import BaseProperty from '../../adapters/property/base-property'
 import BaseResource from '../../adapters/resource/base-resource'
 import BaseRecord from '../../adapters/record/base-record'
+import { ActionContext } from '../../actions'
 
 export const PARAM_SEPARATOR = '~~'
 
@@ -83,15 +84,14 @@ export class Filter {
   /**
    * Populates all filtered properties which refers to other resources
    */
-  async populate(): Promise<Filter> {
+  async populate(context: ActionContext): Promise<Filter> {
     const keys = Object.keys(this.filters)
     for (let index = 0; index < keys.length; index += 1) {
       const key = keys[index]
       const referenceResource = this.resource.decorate().getPropertyByKey(key)?.reference()
       if (referenceResource) {
-        this.filters[key].populated = await referenceResource.findOne(
-          this.filters[key].value as string,
-        )
+        const value = this.filters[key].value as string
+        this.filters[key].populated = await referenceResource.findOne(value, context)
       }
     }
     return this

--- a/src/backend/utils/populator/populate-property.ts
+++ b/src/backend/utils/populator/populate-property.ts
@@ -19,7 +19,7 @@ const isValueSearchable = (value: any): value is string | number => (
 export async function populateProperty(
   records: Array<BaseRecord> | null,
   property: PropertyDecorator,
-  context: ActionContext,
+  context?: ActionContext,
 ): Promise<Array<BaseRecord> | null> {
   const decoratedResource = property.resource()
 

--- a/src/backend/utils/populator/populate-property.ts
+++ b/src/backend/utils/populator/populate-property.ts
@@ -1,5 +1,6 @@
 import { BaseRecord } from '../../adapters'
 import PropertyDecorator from '../../decorators/property/property-decorator'
+import { ActionContext } from '../../actions'
 
 const isValueSearchable = (value: any): value is string | number => (
   ['string', 'bigint', 'number'].includes(typeof value)
@@ -11,12 +12,14 @@ const isValueSearchable = (value: any): value is string | number => (
  *
  * @param {Array<BaseRecord>} records   array of records to populate
  * @param {PropertyDecorator} property  Decorator for the reference property to populate
+ * @param context
  * @private
  * @hide
  */
 export async function populateProperty(
   records: Array<BaseRecord> | null,
   property: PropertyDecorator,
+  context: ActionContext,
 ): Promise<Array<BaseRecord> | null> {
   const decoratedResource = property.resource()
 
@@ -71,7 +74,7 @@ export async function populateProperty(
   }
 
   // now find all referenced records: all users
-  const referenceRecords = await referencedResource.findMany(uniqueExternalIds)
+  const referenceRecords = await referencedResource.findMany(uniqueExternalIds, context)
 
   // even if record has value for this reference - it might not have the referenced record itself
   // this happens quite often in mongodb where there are no constrains on the database

--- a/src/backend/utils/populator/populator.ts
+++ b/src/backend/utils/populator/populator.ts
@@ -10,7 +10,7 @@ import { ActionContext } from '../../actions'
  */
 export async function populator(
   records: Array<BaseRecord>,
-  context:ActionContext,
+  context?:ActionContext,
 ): Promise<Array<BaseRecord>> {
   if (!records || !records.length) {
     return records

--- a/src/backend/utils/populator/populator.ts
+++ b/src/backend/utils/populator/populator.ts
@@ -1,13 +1,16 @@
 import BaseRecord from '../../adapters/record/base-record'
 import { populateProperty } from './populate-property'
+import { ActionContext } from '../../actions'
 
 /**
  * @load ./populator.doc.md
  * @param {Array<BaseRecord>} records
+ * @param context
  * @new In version 3.3
  */
 export async function populator(
   records: Array<BaseRecord>,
+  context:ActionContext,
 ): Promise<Array<BaseRecord>> {
   if (!records || !records.length) {
     return records
@@ -18,7 +21,7 @@ export async function populator(
   const references = allProperties.filter((p) => !!p.reference())
 
   await Promise.all(references.map(async (propertyDecorator) => {
-    await populateProperty(records, propertyDecorator)
+    await populateProperty(records, propertyDecorator, context)
   }))
   return records
 }


### PR DESCRIPTION
Closes #1353

Is backwards compatible, adapters do not need to use `currentAdmin` if they don't need it