### PR TITLE
feat: extend ActionHandler return type

### DIFF
--- a/src/backend/actions/action.interface.ts
+++ b/src/backend/actions/action.interface.ts
@@ -197,13 +197,13 @@ export type BulkActionResponse = ActionResponse & {
  * @alias ActionHandler
  * @async
  * @memberof Action
- * @returns {Promise<T>}
+ * @returns {T | Promise<T>}
  */
 export type ActionHandler<T> = (
   request: ActionRequest,
   response: any,
   context: ActionContext
-) => Promise<T>
+) => T | Promise<T>
 
 /**
  * Before action hook. When it is given - it is performed before the {@link ActionHandler}


### PR DESCRIPTION
Could we extend `ActionHandler` type to allow synchronous actions? I believe `before` and `after` handlers have already been updated in a similar fashion.