### PR TITLE
fix: unable to create custom resource action without component

### DIFF
--- a/src/frontend/interfaces/action/build-action-click-handler.ts
+++ b/src/frontend/interfaces/action/build-action-click-handler.ts
@@ -54,8 +54,8 @@ export const buildActionClickHandler = (
         openModal(modalData)
         return
       }
-      
-      return callApi()
+
+      callApi()
     }
 
     if (href) {

--- a/src/frontend/interfaces/action/build-action-click-handler.ts
+++ b/src/frontend/interfaces/action/build-action-click-handler.ts
@@ -39,19 +39,23 @@ export const buildActionClickHandler = (
       params, action, actionResponseHandler,
     })
 
-    if (action.guard && actionHasComponent(action)) {
-      const modalData: ModalData = {
-        modalProps: {
-          variant: 'danger',
-          label: 'confirm',
-          title: action.guard,
-        },
-        type: 'confirm',
-        resourceId: params.resourceId,
-        confirmAction: callApi,
+    if (actionHasComponent(action)) {
+      if (action.guard) {
+        const modalData: ModalData = {
+          modalProps: {
+            variant: 'danger',
+            label: 'confirm',
+            title: action.guard,
+          },
+          type: 'confirm',
+          resourceId: params.resourceId,
+          confirmAction: callApi,
+        }
+        openModal(modalData)
+        return
       }
-      openModal(modalData)
-      return
+      
+      return callApi()
     }
 
     if (href) {


### PR DESCRIPTION
There was unable to create a custom resource action without a component and guard.

For this configuration, I always get an error: "You have to implement action component for your Action".

```
actionWithoutComponent: {
  actionType: 'resource',
  component: false,
  handler: () => {
    return () => ({
      notice: {
        message: 'Test',
        type: 'success',
      },
    });
  },
},
```

I decided to fix that 😊