### PR TITLE
style: fixed array property background in dark mode

### DIFF
--- a/src/frontend/components/property-type/array/edit.tsx
+++ b/src/frontend/components/property-type/array/edit.tsx
@@ -32,6 +32,7 @@ const ItemRenderer: React.FC<EditProps & ItemRendererProps> = (props) => {
     >
       {(provided): JSX.Element => (
         <Box
+          as="div"
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
@@ -39,6 +40,7 @@ const ItemRenderer: React.FC<EditProps & ItemRendererProps> = (props) => {
           flex
           flexDirection="row"
           alignItems="start"
+          variant="transparent"
           data-testid={property.path}
         >
           <Box as="div" flexGrow={1}>


### PR DESCRIPTION
Set wrapper of array property with variant transparent. Array property can be tested in demo app in `Mongoose -> Complicated` resource.

**Light theme:**
![Screenshot from 2023-05-05 08-31-03](https://user-images.githubusercontent.com/85543813/236390698-b2bb44f6-6d62-40af-8053-b859d85dce54.png)

**Dark theme:**
![Screenshot from 2023-05-05 08-35-20](https://user-images.githubusercontent.com/85543813/236391225-d498b06e-f22a-456b-a74f-05d303802f0e.png)

