### PR TITLE
fix: allow to import original components without HOC-loop

### DIFF
--- a/src/frontend/components/actions/bulk-delete.tsx
+++ b/src/frontend/components/actions/bulk-delete.tsx
@@ -110,4 +110,5 @@ const OverridableFormattedBulkDelete = allowOverride(FormattedBulkDelete, 'Defau
 export {
   OverridableFormattedBulkDelete as default,
   OverridableFormattedBulkDelete as BulkDelete,
+  FormattedBulkDelete as OriginalBulkDelete,
 }

--- a/src/frontend/components/actions/edit.tsx
+++ b/src/frontend/components/actions/edit.tsx
@@ -93,4 +93,5 @@ const OverridableEdit = allowOverride(Edit, 'DefaultEditAction')
 export {
   OverridableEdit as default,
   OverridableEdit as Edit,
+  Edit as OriginalEdit,
 }

--- a/src/frontend/components/actions/list.tsx
+++ b/src/frontend/components/actions/list.tsx
@@ -87,4 +87,5 @@ const OverridableList = allowOverride(List, 'DefaultListAction')
 export {
   OverridableList as default,
   OverridableList as List,
+  List as OriginalList,
 }

--- a/src/frontend/components/actions/new.tsx
+++ b/src/frontend/components/actions/new.tsx
@@ -97,4 +97,5 @@ const OverridableNew = allowOverride(New, 'DefaultNewAction')
 export {
   OverridableNew as default,
   OverridableNew as New,
+  New as OriginalNew,
 }

--- a/src/frontend/components/actions/show.tsx
+++ b/src/frontend/components/actions/show.tsx
@@ -51,4 +51,5 @@ const OverridableShow = allowOverride(Show, 'DefaultShowAction')
 export {
   OverridableShow as default,
   OverridableShow as Show,
+  Show as OriginalShow,
 }

--- a/src/frontend/components/app/action-button/action-button.tsx
+++ b/src/frontend/components/app/action-button/action-button.tsx
@@ -77,4 +77,5 @@ const OverridableActionButton = allowOverride(ActionButton, 'ActionButton')
 export {
   OverridableActionButton as default,
   OverridableActionButton as ActionButton,
+  ActionButton as OriginalActionButton,
 }

--- a/src/frontend/components/app/action-header/action-header.tsx
+++ b/src/frontend/components/app/action-header/action-header.tsx
@@ -125,4 +125,5 @@ const OverridableActionHeader = allowOverride(ActionHeader, 'ActionHeader')
 export {
   OverridableActionHeader as default,
   OverridableActionHeader as ActionHeader,
+  ActionHeader as OriginalActionHeader,
 }

--- a/src/frontend/components/app/action-header/styled-back-button.tsx
+++ b/src/frontend/components/app/action-header/styled-back-button.tsx
@@ -54,4 +54,5 @@ const OverridableStyledBackButton = allowOverride(StyledBackButton, 'StyledBackB
 export {
   OverridableStyledBackButton as default,
   OverridableStyledBackButton as StyledBackButton,
+  StyledBackButton as OriginalStyledBackButton,
 }

--- a/src/frontend/components/app/breadcrumbs.tsx
+++ b/src/frontend/components/app/breadcrumbs.tsx
@@ -92,17 +92,26 @@ const Breadcrumbs: React.FC<BreadcrumbProps> = (props) => {
     <Box flexGrow={1} className={cssClass('Breadcrumbs')} data-css={contentTag}>
       <BreadcrumbLink to={h.dashboardUrl()}>{tl('dashboard')}</BreadcrumbLink>
       {listAction ? (
-        <BreadcrumbLink to={resource.href ? resource.href : '/'} className={record ? 'is-active' : ''}>
+        <BreadcrumbLink
+          to={resource.href ? resource.href : '/'}
+          className={record ? 'is-active' : ''}
+        >
           {tl(resource.name, resource.id)}
         </BreadcrumbLink>
       ) : (
         <BreadcrumbText>{tl(resource.name, resource.id)}</BreadcrumbText>
       )}
-      {action && action.name !== 'list' && <BreadcrumbLink to="#">{ta(action.label)}</BreadcrumbLink>}
+      {action && action.name !== 'list' && (
+        <BreadcrumbLink to="#">{ta(action.label)}</BreadcrumbLink>
+      )}
     </Box>
   )
 }
 
 const OverridableBreadcrumbs = allowOverride(Breadcrumbs, 'Breadcrumbs')
 
-export { OverridableBreadcrumbs as default, OverridableBreadcrumbs as Breadcrumbs }
+export {
+  OverridableBreadcrumbs as default,
+  OverridableBreadcrumbs as Breadcrumbs,
+  Breadcrumbs as OriginalBreadcrumbs,
+}

--- a/src/frontend/components/app/filter-drawer.tsx
+++ b/src/frontend/components/app/filter-drawer.tsx
@@ -149,4 +149,5 @@ const OverridableFilterDrawer = allowOverride(FilterDrawer, 'FilterDrawer')
 export {
   OverridableFilterDrawer as default,
   OverridableFilterDrawer as FilterDrawer,
+  FilterDrawer as OriginalFilterDrawer,
 }

--- a/src/frontend/components/app/logged-in.tsx
+++ b/src/frontend/components/app/logged-in.tsx
@@ -41,4 +41,5 @@ const OverridableLoggedIn = allowOverride(LoggedIn, 'LoggedIn')
 export {
   OverridableLoggedIn as default,
   OverridableLoggedIn as LoggedIn,
+  LoggedIn as OriginalLoggedIn,
 }

--- a/src/frontend/components/app/notice.tsx
+++ b/src/frontend/components/app/notice.tsx
@@ -114,4 +114,8 @@ const mapDispatchToProps = (dispatch): NoticeBoxDispatchFromState => ({
 const ConnectedNoticeBox = connect(mapStateToProps, mapDispatchToProps)(NoticeBox)
 const OverridableConnectedNoticeBox = allowOverride(ConnectedNoticeBox, 'NoticeBox')
 
-export { OverridableConnectedNoticeBox as NoticeBox, OverridableConnectedNoticeBox as default }
+export {
+  OverridableConnectedNoticeBox as NoticeBox,
+  OverridableConnectedNoticeBox as default,
+  ConnectedNoticeBox as OriginalNoticeBox,
+}

--- a/src/frontend/components/app/records-table/no-records.tsx
+++ b/src/frontend/components/app/records-table/no-records.tsx
@@ -36,5 +36,5 @@ const NoRecordsOriginal: React.FC<NoRecordsProps> = (props) => {
 // This hack prevents rollup from throwing an error
 const NoRecords = allowOverride(NoRecordsOriginal, 'NoRecords')
 
-export { NoRecords }
+export { NoRecords, NoRecordsOriginal as OriginalNoRecords }
 export default NoRecords

--- a/src/frontend/components/app/records-table/property-header.tsx
+++ b/src/frontend/components/app/records-table/property-header.tsx
@@ -46,4 +46,5 @@ const OverridablePropertyHeader = allowOverride(PropertyHeader, 'PropertyHeader'
 export {
   OverridablePropertyHeader as default,
   OverridablePropertyHeader as PropertyHeader,
+  PropertyHeader as OriginalPropertyHeader,
 }

--- a/src/frontend/components/app/records-table/record-in-list.tsx
+++ b/src/frontend/components/app/records-table/record-in-list.tsx
@@ -146,4 +146,5 @@ const OverridableRecordInList = allowOverride(RecordInList, 'RecordInList')
 export {
   OverridableRecordInList as default,
   OverridableRecordInList as RecordInList,
+  RecordInList as OriginalRecordInList,
 }

--- a/src/frontend/components/app/records-table/records-table-header.tsx
+++ b/src/frontend/components/app/records-table/records-table-header.tsx
@@ -125,4 +125,5 @@ const OverridableRecordsTableHeader = allowOverride(RecordsTableHeader, 'Records
 export {
   OverridableRecordsTableHeader as default,
   OverridableRecordsTableHeader as RecordsTableHeader,
+  RecordsTableHeader as OriginalRecordsTableHeader,
 }

--- a/src/frontend/components/app/records-table/records-table.tsx
+++ b/src/frontend/components/app/records-table/records-table.tsx
@@ -120,4 +120,5 @@ const OverridableRecordsTable = allowOverride(RecordsTable, 'RecordsTable')
 export {
   OverridableRecordsTable as default,
   OverridableRecordsTable as RecordsTable,
+  RecordsTable as OriginalRecordsTable,
 }

--- a/src/frontend/components/app/records-table/selected-records.tsx
+++ b/src/frontend/components/app/records-table/selected-records.tsx
@@ -67,4 +67,5 @@ const OverridableSelectedRecords = allowOverride(SelectedRecords, 'SelectedRecor
 export {
   OverridableSelectedRecords as default,
   OverridableSelectedRecords as SelectedRecords,
+  SelectedRecords as OriginalSelectedRecords,
 }

--- a/src/frontend/components/app/sidebar/sidebar-branding.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-branding.tsx
@@ -60,3 +60,4 @@ const SidebarBranding: React.FC<Props> = (props) => {
 }
 
 export default allowOverride(SidebarBranding, 'SidebarBranding')
+export { SidebarBranding as OriginalSidebarBranding, SidebarBranding }

--- a/src/frontend/components/app/sidebar/sidebar-footer.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-footer.tsx
@@ -17,3 +17,4 @@ const SidebarFooter: React.FC = () => {
 }
 
 export default allowOverride(SidebarFooter, 'SidebarFooter')
+export { SidebarFooter as OriginalSidebarFooter, SidebarFooter }

--- a/src/frontend/components/app/sidebar/sidebar-pages.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-pages.tsx
@@ -51,3 +51,4 @@ const SidebarPages: React.FC<Props> = (props) => {
 }
 
 export default allowOverride(SidebarPages, 'SidebarPages')
+export { SidebarPages as OriginalSidebarPages, SidebarPages }

--- a/src/frontend/components/app/sidebar/sidebar-resource-section.tsx
+++ b/src/frontend/components/app/sidebar/sidebar-resource-section.tsx
@@ -45,5 +45,5 @@ const SidebarResourceSectionOriginal: FC<SidebarResourceSectionProps> = ({ resou
 // exporting default and named SidebarResourceSection
 const SidebarResourceSection = allowOverride(SidebarResourceSectionOriginal, 'SidebarResourceSection')
 
-export { SidebarResourceSection }
+export { SidebarResourceSection, SidebarResourceSectionOriginal as OriginalSidebarResourceSection }
 export default SidebarResourceSection

--- a/src/frontend/components/app/sidebar/sidebar.tsx
+++ b/src/frontend/components/app/sidebar/sidebar.tsx
@@ -62,5 +62,5 @@ const SidebarOriginal: React.FC<Props> = (props) => {
 
 const Sidebar = allowOverride(SidebarOriginal, 'Sidebar')
 
-export { Sidebar }
+export { Sidebar, SidebarOriginal as OriginalSidebar }
 export default Sidebar

--- a/src/frontend/components/app/top-bar.tsx
+++ b/src/frontend/components/app/top-bar.tsx
@@ -53,4 +53,4 @@ const TopBar: React.FC<Props> = (props) => {
 
 const OverridableTopbar = allowOverride<Props>(TopBar, 'TopBar')
 
-export { OverridableTopbar as TopBar, OverridableTopbar as default }
+export { OverridableTopbar as TopBar, OverridableTopbar as default, TopBar as OriginalTopBar }

--- a/src/frontend/components/app/version.tsx
+++ b/src/frontend/components/app/version.tsx
@@ -46,4 +46,5 @@ const OverridableVersion = allowOverride(Version, 'Version')
 export {
   OverridableVersion as default,
   OverridableVersion as Version,
+  Version as OriginalVersion,
 }


### PR DESCRIPTION
This PR fixes a bug which prevented you from importing an original component, modifying the props and returning the original component with modified props.

Example:
```typescript
import React from 'react';
import { OriginalRecordInList, RecordInListProps } from 'adminjs';

const RecordInListOverride: React.FC<RecordInListProps> = (props) => {
  const { resource, record } = props;

  // If resource is different than SomeResource, return original component
  if (resource.id !== 'SomeResource') {
    return <OriginalRecordInList {...props} />;
  }

  const updatedProps = {
    ...props,
    record: {
      ...record,
      recordActions: record.recordActions.filter((a) => a.name !== 'show'),
    },
  };

  // Else modify props so that "show" action is not available
  return <OriginalRecordInList {...updatedProps} />;
};

export default RecordInListOverride;
```

Previously, importing:
```typescript
import { RecordInList as OriginalRecordInList, RecordInListProps } from 'adminjs';
```
would cause `allowOverride` HOC-loop which crashed the browser tab.

All exported `original` components are now prefixed with `Original(...)`:
`RecordInList` -> `OriginalRecordInList`