### PR TITLE
Resolve actions issues

### DIFF
--- a/src/backend/actions/delete/delete-action.ts
+++ b/src/backend/actions/delete/delete-action.ts
@@ -30,11 +30,19 @@ export const DeleteAction: Action<RecordActionResponse> = {
    */
   handler: async (request, _response, context) => {
     const { record, resource, currentAdmin, h } = context
+
     if (!request.params.recordId || !record) {
       throw new NotFoundError([
         'You have to pass "recordId" to Delete Action',
       ].join('\n'), 'Action#handler')
     }
+
+    if (request.method === 'get') {
+      return {
+        record: record.toJSON(context.currentAdmin),
+      }
+    }
+
     try {
       await resource.delete(request.params.recordId, context)
     } catch (error) {
@@ -51,6 +59,7 @@ export const DeleteAction: Action<RecordActionResponse> = {
       }
       throw error
     }
+
     return {
       record: record.toJSON(currentAdmin),
       redirectUrl: h.resourceUrl({ resourceId: resource._decorated?.id() || resource.id() }),

--- a/src/frontend/components/app/error-message.tsx
+++ b/src/frontend/components/app/error-message.tsx
@@ -42,7 +42,7 @@ const NoResourceError: React.FC<{ resourceId: string }> = (props) => {
   const { translateMessage } = useTranslation()
   return (
     <InfoBox
-      title={translateMessage('pageNotFound', resourceId, { resourceId })}
+      title={translateMessage('pageNotFound_title', resourceId, { resourceId })}
       illustration="NotFound"
       testId="NoResourceError"
     >
@@ -58,7 +58,7 @@ const NoActionError: React.FC<{ resourceId: string; actionName: string }> = (pro
   const { translateMessage } = useTranslation()
   return (
     <InfoBox
-      title={translateMessage('pageNotFound', resourceId, { resourceId })}
+      title={translateMessage('pageNotFound_title', resourceId, { resourceId })}
       illustration="NotFound"
       testId="NoActionError"
     >
@@ -77,7 +77,7 @@ const NoRecordError: React.FC<{
   const { translateMessage } = useTranslation()
   return (
     <InfoBox
-      title={translateMessage('pageNotFound', resourceId, { resourceId })}
+      title={translateMessage('pageNotFound_title', resourceId, { resourceId })}
       illustration="NotFound"
       testId="NoRecordError"
     >

--- a/src/frontend/components/routes/resource-action.tsx
+++ b/src/frontend/components/routes/resource-action.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { useParams } from 'react-router'
 
 import BaseActionComponent from '../app/base-action-component.js'
-import { ResourceJSON } from '../../interfaces/index.js'
+import { ResourceJSON, actionHasDisabledComponent } from '../../interfaces/index.js'
 import { ReduxState } from '../../store/store.js'
 import { NoResourceError, NoActionError } from '../app/error-message.js'
 import { ResourceActionParams } from '../../../backend/utils/view-helpers/view-helpers.js'
@@ -31,7 +31,7 @@ const ResourceAction: React.FC<Props> = (props) => {
     return (<NoResourceError resourceId={resourceId!} />)
   }
   const action = resource.resourceActions.find((r) => r.name === actionName)
-  if (!action) {
+  if (!action || actionHasDisabledComponent(action)) {
     return (<NoActionError resourceId={resourceId!} actionName={actionName!} />)
   }
 

--- a/src/frontend/interfaces/action/action-has-component.ts
+++ b/src/frontend/interfaces/action/action-has-component.ts
@@ -1,5 +1,9 @@
 import { ActionJSON } from './action-json.interface.js'
 
-export const actionHasComponent = (action: ActionJSON): boolean => (
+export const actionHasDisabledComponent = (action: ActionJSON): boolean => (
   typeof action.component !== 'undefined' && action.component === false
+)
+
+export const actionHasCustomComponent = (action: ActionJSON): boolean => (
+  typeof action.component === 'string'
 )

--- a/src/frontend/interfaces/action/build-action-click-handler.ts
+++ b/src/frontend/interfaces/action/build-action-click-handler.ts
@@ -4,7 +4,7 @@
 import { NavigateFunction } from 'react-router'
 
 import { DifferentActionParams, useActionResponseHandler } from '../../hooks/index.js'
-import { actionHasComponent } from './action-has-component.js'
+import { actionHasDisabledComponent } from './action-has-component.js'
 import { actionHref } from './action-href.js'
 import { ActionJSON } from './action-json.interface.js'
 import { buildActionCallApiTrigger } from './build-action-api-call-trigger.js'
@@ -39,7 +39,8 @@ export const buildActionClickHandler = (
       params, action, actionResponseHandler,
     })
 
-    if (actionHasComponent(action)) {
+    // Action has "component" option set to "false" explicitly in it's configuration
+    if (actionHasDisabledComponent(action)) {
       if (action.guard) {
         const modalData: ModalData = {
           modalProps: {
@@ -51,13 +52,18 @@ export const buildActionClickHandler = (
           resourceId: params.resourceId,
           confirmAction: callApi,
         }
+
+        // If confirmation is required, action trigger should be handled in modal
         openModal(modalData)
         return
       }
 
+      // If no confirmation is required, call API
       callApi()
+      return
     }
 
+    // Default behaviour - you're navigated to action URL and logic is performed on it's route
     if (href) {
       navigate(href)
     }

--- a/src/frontend/interfaces/action/call-action-api.ts
+++ b/src/frontend/interfaces/action/call-action-api.ts
@@ -15,18 +15,26 @@ export function callActionApi<K extends ActionResponse>(
   let promise: Promise<AxiosResponse<K>>
   const { recordId, recordIds, resourceId } = params
 
+  /* Temporary workaround to avoid breaking changes.
+    TODO: For v8 release, rewrite actions to support PUT & DELETE methods.
+    Actions should have an option to configure a default method for action buttons. */
+  let method = 'get'
+  if (action.name === 'delete') {
+    method = 'post'
+  }
+
   switch (action.actionType) {
   case 'record':
     if (!recordId) {
       throw new Error('You have to specify "recordId" for record action')
     }
     promise = api.recordAction({
-      resourceId, actionName: action.name, recordId, search,
+      resourceId, actionName: action.name, recordId, search, method,
     }) as any
     break
   case 'resource':
     promise = api.resourceAction({
-      resourceId, actionName: action.name,
+      resourceId, actionName: action.name, method,
     }) as any
     break
   case 'bulk':
@@ -34,7 +42,7 @@ export function callActionApi<K extends ActionResponse>(
       throw new Error('You have to specify "recordIds" for bulk action')
     }
     promise = api.bulkAction({
-      resourceId, actionName: action.name, recordIds, search,
+      resourceId, actionName: action.name, recordIds, search, method,
     }) as any
     break
   default:


### PR DESCRIPTION
Resolves:
https://github.com/SoftwareBrothers/adminjs/issues/1507
https://github.com/SoftwareBrothers/adminjs/issues/1447
as a temporary workaround.

`delete` action now performs an actual delete only if `request.method` is `post`. Other potentially destructive built-in actions (`new`, `edit`, `bulkDelete`) have already differentiated between `get` and `post`. In version 8 we should rewrite action buttons & click handlers so that "default method" for action can also be configured. We should also introduce `PATCH`, `PUT` and `DELETE` request methods but this also comes with breaking changes. When adding new custom actions, you should add `if (request.method === 'xxx')` checks at the start to avoid destructive behaviours.
Additionally, when you enter a route for an action that has it's component disabled (by explicitly setting `component` to `false`), it will no longer run a `GET` request.

Also fixed an issue where a clicking a resource action without component would navigate to action's page and inform about missing component.

Fixed "pageNotFound" translation.