### PR TITLE
fix: allow bundling .mjs and .mts files via ComponentLoader

### DIFF
--- a/src/backend/utils/component-loader.ts
+++ b/src/backend/utils/component-loader.ts
@@ -73,7 +73,7 @@ export class ComponentLoader {
   }
 
   public static resolveFilePath(filePath: string, caller: string): string {
-    const extensions = ['.jsx', '.js', '.ts', '.tsx']
+    const extensions = ['.jsx', '.js', '.ts', '.tsx', '.mts', '.mjs']
     const src = path.isAbsolute(filePath)
       ? filePath
       : relativeFilePathResolver(filePath, new RegExp(`.*.{1}${caller}`))


### PR DESCRIPTION
When using AdminJS with CommonJS projects (like NestJS), the only way I could have custom React components working has been by putting them into `.mjs` files (this unfortunately loses typing as [TypeScript doesn't support `.mtsx`](https://github.com/microsoft/TypeScript/issues/44442), but that's how it is...)

Currently, `ComponentLoader` doesn't allow this file extension, but I don't think there is any problem by allowing them? It worked for me at least, so here is the change :) 