### PR TITLE
fix: list action populate issue

### DIFF
--- a/src/frontend/components/property-type/reference/reference-value.tsx
+++ b/src/frontend/components/property-type/reference/reference-value.tsx
@@ -27,7 +27,7 @@ const ReferenceValue: React.FC<Props> = (props) => {
     throw new Error(`property: "${property.path}" does not have a reference`)
   }
 
-  if (populated && populated.recordActions.find((a) => a.name === 'show')) {
+  if (populated?.recordActions?.find((a) => a.name === 'show')) {
     const href = h.recordActionUrl({
       resourceId: property.reference, recordId: refId, actionName: 'show',
     })


### PR DESCRIPTION
Explain issue:

I'm facing an issue with a resource list. The error message reads: "TypeError: Cannot read properties of undefined (reading 'find')." I have attached an image for more details. 

I suspect that the issue is due to a removed relationship.

"@adminjs/express": "^6.0.1",
"@adminjs/mongoose": "^4.0.0",
"adminjs": "^7.5.2",

![image](https://github.com/SoftwareBrothers/adminjs/assets/80238484/6024c215-98ca-4026-b977-ce08c80e163c)
