### PR TITLE
Making adminjs work on Deno

### DIFF
--- a/src/backend/utils/view-helpers/view-helpers.ts
+++ b/src/backend/utils/view-helpers/view-helpers.ts
@@ -11,6 +11,10 @@ try {
   if (error.message !== 'window is not defined') {
     throw error
   }
+} finally {
+  if (!globalAny) {
+    globalAny = {}
+  }
 }
 
 /**

--- a/src/frontend/utils/api-client.ts
+++ b/src/frontend/utils/api-client.ts
@@ -19,6 +19,10 @@ try {
   } else {
     globalAny = { isOnServer: true }
   }
+} finally {
+  if (!globalAny) {
+    globalAny = { isOnServer: true }
+  }
 }
 
 /**


### PR DESCRIPTION
Thank you for such an amazing piece of software.

This PR fixes two small issues that prevent AdminJS from working on Deno.

## The problem:

AdminJS assumes that the environment is either a browser or NodeJS, only.

```sh
user@host ~/d/b/adminjs-deno (main)> deno task dev                                          (base) 
Task dev deno run --watch -A src/app.ts
Watcher Process started.
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'isOnServer')
    at Function.getBaseUrl (file:///Users/user/dev/brickpop/adminjs-deno/node_modules/.deno/adminjs@7.6.0/node_modules/adminjs/lib/frontend/utils/api-client.js:104:19)
    at new ApiClient (file:///Users/user/dev/brickpop/adminjs-deno/node_modules/.deno/adminjs@7.6.0/node_modules/adminjs/lib/frontend/utils/api-client.js:98:30)
    at file:///Users/user/dev/brickpop/adminjs-deno/node_modules/.deno/adminjs@7.6.0/node_modules/adminjs/lib/frontend/hooks/use-record/use-record.js:11:13
```

## The solution

Adding a check to ensure that `globalAny` is treated as in a server.

## Working example

AdminJS app running on Deno:
https://github.com/brickpop/adminjs-deno

You need to run the `deno task setup` to apply the workaround that fixes the issue. See `scripts/setup.ts`
