### PR TITLE
feat: support subproperties as a title

### DIFF
--- a/src/backend/decorators/resource/resource-decorator.ts
+++ b/src/backend/decorators/resource/resource-decorator.ts
@@ -250,7 +250,7 @@ class ResourceDecorator {
 
     const properties = Object.values(this.properties)
     if (this.options.titleProperty) {
-      titleProperty = properties.find((p) => p.propertyPath === this.options.titleProperty)
+      titleProperty = this.getPropertyByKey(this.options.titleProperty)
     } else {
       titleProperty = properties.find((p) => p.isTitle())
     }


### PR DESCRIPTION
This change allows setting a sub property as a title of resource.

For example:
```ts
      resource: {
        model: getModelByName('Sport'),
        client: prisma,
      },
      options: {
        titleProperty: 'translation.en',
        listProperties: ['translation.ja', 'translation.en'],
        properties: {
          translation: { type: 'mixed' },
          'translation.ja': { type: 'string' },
          'translation.en': { type: 'string' },
          // some other props
        },
      },
```

In master branch such `titleProperty` is just ignored which is an unexpected behavior.