### PR TITLE
fix: incorrect file path in Windows platform

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -8,7 +8,7 @@
         "camelize", "datepicker", "camelcase", "fullwidth", "wysiwig", "Helvetica", "Neue",
         "Arial", "nowrap", "textfield", "scrollable", "flexbox", "treal", "xxxl",
         "adminjs", "Checkmark", "overridable", "Postgres", "Hana", "Wojtek", "Krysiak", "bigint",
-        "borderless", "metadetaksamosone", "esrever", "jsnext"
+        "borderless", "metadetaksamosone", "esrever", "jsnext", "Никита"
     ],
     "ignorePaths": [
         "src/frontend/assets/**/*"

--- a/src/utils/file-resolver.ts
+++ b/src/utils/file-resolver.ts
@@ -23,17 +23,17 @@ export const relativeFilePathResolver = (filePath: string, syntax: RegExp): stri
   * Before: \D:\%D0%9D%D0%B8%D0%BA%D0%B8%D1%82%D0%B0\project\dist\components\photo
   * After: \D:\Никита\project\dist\components\photo
   */
-  const resultPath = path.join(path.dirname(executionPath), filePath).replace(/^file:/gi, '')
-  
+  const resultPath = decodeURIComponent(path.join(path.dirname(executionPath), filePath).replace(/^file:/gi, ''))
+
   /**
   * If the separator is a backslash, remove the first one.
   * If you do not do this, the file will not be found
-  * 
+  *
   * Required for Windows
   */
   if (path.sep === '\\' && resultPath[0] === '\\') {
     return resultPath.slice(1)
   }
-  
+
   return resultPath
 }

--- a/src/utils/file-resolver.ts
+++ b/src/utils/file-resolver.ts
@@ -16,5 +16,24 @@ export const relativeFilePathResolver = (filePath: string, syntax: RegExp): stri
     throw new Error('STACK does not have a file url. Check out if the node version >= 8')
   }
   const executionPath = (pathNode8 && pathNode8[1]) || (pathNode10 && pathNode10[1])
-  return path.join(path.dirname(executionPath as string), filePath).replace(/^file:/gi, '')
+
+  /**
+  * decodeURIComponent used to decode parts of a path.
+  *
+  * Before: \D:\%D0%9D%D0%B8%D0%BA%D0%B8%D1%82%D0%B0\project\dist\components\photo
+  * After: \D:\Никита\project\dist\components\photo
+  */
+  const resultPath = path.join(path.dirname(executionPath), filePath).replace(/^file:/gi, '')
+  
+  /**
+  * If the separator is a backslash, remove the first one.
+  * If you do not do this, the file will not be found
+  * 
+  * Required for Windows
+  */
+  if (path.sep === '\\' && resultPath[0] === '\\') {
+    return resultPath.slice(1)
+  }
+  
+  return resultPath
 }

--- a/src/utils/file-resolver.ts
+++ b/src/utils/file-resolver.ts
@@ -23,7 +23,7 @@ export const relativeFilePathResolver = (filePath: string, syntax: RegExp): stri
   * Before: \D:\%D0%9D%D0%B8%D0%BA%D0%B8%D1%82%D0%B0\project\dist\components\photo
   * After: \D:\Никита\project\dist\components\photo
   */
-  const resultPath = decodeURIComponent(path.join(path.dirname(executionPath), filePath).replace(/^file:/gi, ''))
+  const resultPath = decodeURIComponent(path.join(path.dirname(executionPath as string), filePath).replace(/^file:/gi, ''))
 
   /**
   * If the separator is a backslash, remove the first one.


### PR DESCRIPTION
When importing a [custom component](https://docs.adminjs.co/ui-customization/writing-your-own-components) on the Windows platform, there was a problem with determining the path. This PR also fixes the problem with the Cyrillic alphabet in the file path.

Before:
\D:\%D0%9D%D0%B8%D0%BA%D0%B8%D1%82%D0%B0\project\dist\components\photo

After:
D:\Никита\project\dist\components\photo