### PR TITLE
fix: skip populate hidden reference

### DIFF
--- a/src/backend/utils/populator/populator.ts
+++ b/src/backend/utils/populator/populator.ts
@@ -18,8 +18,7 @@ export async function populator(
   const resourceDecorator = records[0].resource.decorate()
   const allProperties = Object.values(resourceDecorator.getFlattenProperties())
 
-  const references = allProperties.filter((p) => !!p.reference())
-
+  const references = allProperties.filter((p) => !!p.reference() && (p.isVisible('show') || p.isVisible('list') || p.isVisible('edit') || p.isVisible('filter')))
   await Promise.all(references.map(async (propertyDecorator) => {
     await populateProperty(records, propertyDecorator, context)
   }))


### PR DESCRIPTION
Supporting to skip loading invisible reference property.

Currently, it loads all of the related resources even though the property has been set as `isVisible`: false which will result to unnecessary data load and query.