### PR TITLE
fix: use refresh token URL from options instead of hardcoded

### DIFF
--- a/src/adminjs-options.interface.ts
+++ b/src/adminjs-options.interface.ts
@@ -67,6 +67,10 @@ export interface AdminJSOptions {
    */
   loginPath?: string;
   /**
+   * url to refresh the token, default to `/admin/refresh-token`
+   */
+  refreshTokenPath?: string;
+  /**
    * Array of all Databases which are supported by AdminJS via adapters
    */
   databases?: Array<any>;

--- a/src/frontend/store/initialize-store.ts
+++ b/src/frontend/store/initialize-store.ts
@@ -57,10 +57,24 @@ export const initializeStore = async (
   store.dispatch(initializeAssets(assets || {}))
   if (theme) store.dispatch(initializeTheme(theme))
 
-  const { loginPath, logoutPath, rootPath, dashboard, pages, assetsCDN } = admin.options
+  const {
+    loginPath,
+    logoutPath,
+    refreshTokenPath,
+    rootPath,
+    dashboard,
+    pages,
+    assetsCDN
+  } = admin.options
 
   store.dispatch(initializePages(pagesToStore(pages)))
-  store.dispatch(initializePaths({ loginPath, logoutPath, rootPath, assetsCDN }))
+  store.dispatch(initializePaths({
+    loginPath,
+    logoutPath,
+    refreshTokenPath,
+    rootPath,
+    assetsCDN
+  }))
   store.dispatch(setCurrentAdmin(currentAdmin))
   store.dispatch(initializeDashboard(dashboard))
   store.dispatch(

--- a/src/frontend/utils/api-client.ts
+++ b/src/frontend/utils/api-client.ts
@@ -257,7 +257,7 @@ class ApiClient {
 
   async refreshToken(data: Record<string, any>) {
     const response = await this.client.request({
-      url: '/refresh-token',
+      url: globalAny.REDUX_STATE.paths.refreshTokenPath,
       method: 'POST',
       data,
     })


### PR DESCRIPTION
The refresh token URL was hardcoded and ignored the configured options, causing it to break in custom setups. This update makes the URL dynamic based on the options.